### PR TITLE
Weight and event info producers in production sequence

### DIFF
--- a/CatProducer/python/catSetup_cff.py
+++ b/CatProducer/python/catSetup_cff.py
@@ -34,6 +34,15 @@ def catSetup(process, runOnMC=True, doSecVertex=True):
     process.catSecVertexs.elecSrc = cms.InputTag(catElectronsSource)
     process.catSecVertexs.vertexLabel = cms.InputTag(catVertexSource)
 
+    process.load("CATTools.CatProducer.recoEventInfo_cfi")
+    process.out.outputCommands.append("keep *_recoEventInfo_*_*")
+    if runOnMC:
+        ## Load MC dependent producers
+        process.load("CATTools.CatProducer.pdfWeight_cff")
+        process.load("CATTools.CatProducer.pileupWeight_cff")
+        process.out.outputCommands.append("keep *_pdfWeights_*_*")
+        process.out.outputCommands.append("keep *_pileupWeight_*_*")
+
     if not runOnMC:
         process.makeCatCandidates.remove(process.catGenJets)
         process.catMuons.runOnMC = cms.bool(False)

--- a/CatProducer/python/pdfWeight_cff.py
+++ b/CatProducer/python/pdfWeight_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 pdfWeight = cms.EDProducer("PDFWeightsProducer",
+    genEventInfo = cms.InputTag("generator"),
     pdfName = cms.string("cteq66.LHgrid"),
     generatedPdfName = cms.string("cteq66.LHgrid"),
 )

--- a/CatProducer/python/recoEventInfo_cfi.py
+++ b/CatProducer/python/recoEventInfo_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 recoEventInfo = cms.EDProducer("RecoEventInfoProducer",
-    vertex = cms.InputTag("goodOfflinePrimaryVertices"),
+    vertex = cms.InputTag("offlineSlimmedPrimaryVertices"),
     triggerResults = cms.InputTag("TriggerResults", "", "HLT"),
     HLT = cms.PSet(
         DoubleMu = cms.vstring(

--- a/CatProducer/python/recoEventInfo_cfi.py
+++ b/CatProducer/python/recoEventInfo_cfi.py
@@ -7,19 +7,6 @@ recoEventInfo = cms.EDProducer("RecoEventInfoProducer",
         DoubleMu = cms.vstring(
             "HLT_Mu17_Mu8_v*", "HLT_Mu17_TkMu8_v*"
         ),
-        DoubleElectron = cms.vstring(
-            "HLT_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*",
-        ),
-        MuEG = cms.vstring(
-            "HLT_Mu17_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*",
-            "HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v*",
-        ),
-        MuJet = cms.vstring(
-            "HLT_IsoMu24_eta2p1_v*",
-        ),
-        ElJet = cms.vstring(
-            "HLT_Ele25_CaloIdVL_*", "HLT_Ele25_CaloIdVT_*",
-        ),
     ),
 )
 


### PR DESCRIPTION
Weight producers and Event info producers are added in the main CAT production.

Note that producers are not explicitly added into sequence, 
they are automatically chosen by the framework if unscheduled mode is on.
