### PR TITLE
about keeping pass/fail and prescale of the HLTs

### DIFF
--- a/CatProducer/plugins/RecoEventInfoProducer.cc
+++ b/CatProducer/plugins/RecoEventInfoProducer.cc
@@ -133,7 +133,7 @@ void RecoEventInfoProducer::produce(edm::Event& event, const edm::EventSetup& ev
         //if ( hltHandle->accept(trigIndex) ) { isPassed = true; break; }
         if ( hltHandle->accept(trigIndex) ) { isPassed = true; HLTListPassFail.push_back(1); break;} 
         else {HLTListPassFail.push_back(0); }
-      }
+      } else {HLTListPassFail.push_back(0); }
       //const int psValue = hltConfig_.prescaleValue(event, eventSetup, trigName);
     }
     event.put(std::auto_ptr<int>(new int(isPassed)), "HLT"+hltGroupName);


### PR DESCRIPTION
in a event:
 HLTNameList : vector string
 HLTListPassFail : vector int
 HLTPrescaleList : vector int

We can keep all triggers by single trigger set as (name, pass/fail/, prescale).
++++++++
Dataset:
vector<int>                    "recoEventInfo"             "HLTListPassFail"   "CAT"
vector<int>                    "recoEventInfo"             "HLTPrescaleList"   "CAT"
vector<string>                 "recoEventInfo"             "HLTNameList"     "CAT"
++++
However I need to check more detail.
