### PR TITLE
Parton top update

### DIFF
--- a/CatProducer/plugins/PartonTopProducer.cc
+++ b/CatProducer/plugins/PartonTopProducer.cc
@@ -87,6 +87,12 @@ void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
     const reco::Candidate* t = tQuarks.at(i);
     const reco::Candidate* tLast = getLast(t);
     reco::GenParticleRef tRef = buildGenParticle(tLast, partonRefHandle, partons);
+  }
+
+  for ( int i=0, n=tQuarks.size(); i<n; ++i )
+  {
+    const reco::Candidate* tLast = getLast(tQuarks.at(i));
+    reco::GenParticleRef tRef(partonRefHandle, i);
 
     const reco::Candidate* w = 0;
     const reco::Candidate* b = 0;
@@ -95,7 +101,7 @@ void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
       const reco::Candidate* dau = tLast->daughter(j);
       const unsigned int dauAbsId = abs(dau->pdgId());
       if ( dauAbsId == 24 and !w ) w = dau;
-      else if ( dauAbsId == 5 and !b ) b = dau;
+      else if ( dauAbsId < 6 and !b ) b = dau;
     }
     if ( !w or !b ) continue;
     reco::GenParticleRef wRef = buildGenParticle(w, partonRefHandle, partons);

--- a/CatProducer/plugins/PartonTopProducer.cc
+++ b/CatProducer/plugins/PartonTopProducer.cc
@@ -26,7 +26,7 @@ public:
   enum DecayMode { CH_HADRON = 1, CH_MUON, CH_ELECTRON, CH_TAU_HADRON, CH_TAU_MUON, CH_TAU_ELECTRON };
 
 private:
-  const reco::Candidate* getLast(const reco::Candidate* p);
+  const reco::Candidate* getLast(const reco::Candidate* p) const;
   reco::GenParticleRef buildGenParticle(const reco::Candidate* p, reco::GenParticleRefProd& refHandle,
                                         std::auto_ptr<reco::GenParticleCollection>& outColl) const;
 
@@ -201,12 +201,24 @@ void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
   event.put(modes, "modes");
 }
 
-const reco::Candidate* PartonTopProducer::getLast(const reco::Candidate* p)
+const reco::Candidate* PartonTopProducer::getLast(const reco::Candidate* p) const
 {
+  int nDecay = 0;
+  std::vector<const reco::Candidate*> sameCopies;
   for ( size_t i=0, n=p->numberOfDaughters(); i<n; ++i )
   {
     const reco::Candidate* dau = p->daughter(i);
-    if ( p->pdgId() == dau->pdgId() ) return getLast(dau);
+    const int dauId = dau->pdgId();
+    if ( dauId == 22 or dauId == 21 ) continue;
+    if ( p->pdgId() == dau->pdgId() ) sameCopies.push_back(dau);
+    else ++nDecay;
+  }
+  if ( nDecay == 0 )
+  {
+    for ( const auto dau : sameCopies )
+    {
+      if ( p->pdgId() == dau->pdgId() ) return getLast(dau);
+    }
   }
   return p;
 }


### PR DESCRIPTION
Update PartonTopProducer

**Change particle ordering**
Top quarks are stored at the first. partons[0] and partons[1] will give top and anti-top.
No physics change is expected but there can be little modification to user analysis macros.

**Allow t->Wq, q!=b decays**
Some MC with CKM allows t->Ws t->Wd decays.
Small change in gen level event selection.

**Fix to getLast()**
Trace daughter if decays to same particle and no other decay products except photons and gluons.
In some cases, W decay products contains copy of W itself without daughter particles -
Imagine a decay chain:
   W_1(3 daughters)->W_2(0 dau) + l + nu
W_1 will be selected with this new code.
But in the decay chain
  W_a -> W_b + photons... -> l + nu + photons
W_b will be selected.
