### PR TITLE
Jets before hadronization

### DIFF
--- a/CatProducer/plugins/PartonTopProducer.cc
+++ b/CatProducer/plugins/PartonTopProducer.cc
@@ -4,6 +4,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/ClusterSequence.hh"
+#include "RecoJets/JetProducers/interface/JetSpecific.h"
 
 #include "CommonTools/Utils/interface/PtComparator.h"
 
@@ -32,17 +35,29 @@ private:
 
   typedef reco::Particle::LorentzVector LorentzVector;
 
+  const double jetMinPt_, jetMaxEta_;
+  typedef fastjet::JetDefinition JetDef;
+  std::shared_ptr<JetDef> fjDef_;
+  const reco::Particle::Point genVertex_;
+
 private:
   edm::EDGetTokenT<edm::View<reco::Candidate> > genParticleToken_;
 };
 
-PartonTopProducer::PartonTopProducer(const edm::ParameterSet& pset)
+PartonTopProducer::PartonTopProducer(const edm::ParameterSet& pset):
+  jetMinPt_(pset.getParameter<double>("jetMinPt")),
+  jetMaxEta_(pset.getParameter<double>("jetMaxEta")),
+  genVertex_(0,0,0)
 {
   genParticleToken_ = consumes<edm::View<reco::Candidate> >(pset.getParameter<edm::InputTag>("genParticles"));
+  const double jetConeSize = pset.getParameter<double>("jetConeSize");
+  fjDef_ = std::shared_ptr<JetDef>(new JetDef(fastjet::antikt_algorithm, jetConeSize));
 
   produces<reco::GenParticleCollection>();
   produces<int>("channel");
   produces<std::vector<int> >("modes");
+
+  produces<reco::GenJetCollection>("qcdJets");
 }
 
 void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
@@ -56,15 +71,18 @@ void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
   std::auto_ptr<int> channel(new int(CH_NONE));
   std::auto_ptr<std::vector<int> > modes(new std::vector<int>());
 
+  std::auto_ptr<reco::GenJetCollection> qcdJets(new reco::GenJetCollection);
+
   // Collect top quarks and unstable B-hadrons
   std::vector<const reco::Candidate*> tQuarks;
+  std::vector<const reco::Candidate*> qcdParticles;
   for ( size_t i=0, n=genParticleHandle->size(); i<n; ++i )
   {
     const reco::Candidate& p = genParticleHandle->at(i);
     const int status = p.status();
     if ( status == 1 ) continue;
 
-    // Collect parton level objects. Ignore gluons and photons
+    // Collect parton level objects.
     const int absPdgId = abs(p.pdgId());
     if ( absPdgId == 6 )
     {
@@ -77,6 +95,20 @@ void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
         if ( dauId == p.pdgId() ) { toKeep = false; break; }
       }
       if ( toKeep ) tQuarks.push_back(&p);
+    }
+    else if ( absPdgId < 6 or absPdgId == 21 )
+    {
+      // QCD particles : select one after parton shower, before hadronization
+      bool toKeep = true;
+      for ( size_t j=0, m=p.numberOfDaughters(); j<m; ++j )
+      {
+        const int absDauId = abs(p.daughter(j)->pdgId());
+        if ( absDauId < 6 or absPdgId == 21 ) { toKeep = false; break; }
+      }
+      if ( toKeep )
+      {
+        qcdParticles.push_back(&p);
+      }
     }
   }
   // Build top quark decay tree in parton level
@@ -196,9 +228,41 @@ void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
     else if ( nLepton == 2 ) *channel = CH_FULLLEPTON;
   }
 
+  // Make genJets using particles after PS, but before hadronization
+  std::vector<fastjet::PseudoJet> fjInputs;
+  fjInputs.reserve(qcdParticles.size());
+  for ( const reco::Candidate* p : qcdParticles )
+  {
+    fjInputs.push_back(fastjet::PseudoJet(p->px(), p->py(), p->pz(), p->energy()));
+    const int index = p-(&*genParticleHandle->begin());
+    fjInputs.back().set_user_index(index);
+  }
+  fastjet::ClusterSequence fjClusterSeq(fjInputs, *fjDef_);
+  std::vector<fastjet::PseudoJet> fjJets = fastjet::sorted_by_pt(fjClusterSeq.inclusive_jets(jetMinPt_));
+  qcdJets->reserve(fjJets.size());
+  for ( auto& fjJet : fjJets )
+  {
+    if ( abs(fjJet.eta()) > jetMaxEta_ ) continue;
+    const auto& fjCons = fjJet.constituents();
+    std::vector<reco::CandidatePtr> cons;
+    cons.reserve(fjCons.size());
+    for ( auto con : fjCons )
+    {
+      const size_t index = con.user_index();
+      cons.push_back(genParticleHandle->ptrAt(index));
+    }
+
+    const LorentzVector jetP4(fjJet.px(), fjJet.py(), fjJet.pz(), fjJet.E());
+    reco::GenJet qcdJet;
+    reco::writeSpecific(qcdJet, jetP4, genVertex_, cons, eventSetup);
+
+    qcdJets->push_back(qcdJet);
+  }
+
   event.put(partons);
   event.put(channel, "channel");
   event.put(modes, "modes");
+  event.put(qcdJets, "qcdJets");
 }
 
 const reco::Candidate* PartonTopProducer::getLast(const reco::Candidate* p) const

--- a/CatProducer/python/pseudoTop_cff.py
+++ b/CatProducer/python/pseudoTop_cff.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 partonTop = cms.EDProducer("PartonTopProducer",
     genParticles = cms.InputTag("prunedGenParticles"),
+    jetMinPt = cms.double(20),
+    jetMaxEta = cms.double(2.5),
 )
 
 from TopQuarkAnalysis.TopEventProducers.producers.pseudoTop_cfi import *

--- a/CatProducer/test/pseudoTop_cfg.py
+++ b/CatProducer/test/pseudoTop_cfg.py
@@ -16,7 +16,7 @@ process.source.fileNames = [
 '/store/mc/Phys14DR/TTJets_MSDecaysCKM_central_Tune4C_13TeV-madgraph-tauola/MINIAODSIM/PU20bx25_PHYS14_25_V1-v1/00000/00C90EFC-3074-E411-A845-002590DB9262.root',
 ]
 
-process.load("CATTools.CatProducer.pseudoTop_cfi")
+process.load("CATTools.CatProducer.pseudoTop_cff")
 
 process.out = cms.OutputModule("PoolOutputModule", 
     fileName = cms.untracked.string("out.root"),


### PR DESCRIPTION
Re-opening #114 

**Needs physics discussion with TOP-13-010 and future ttbb analyzers**

This PR adds one more jet collection from PartonTopProducer.
No change in existing objects.

In the ttbb analysis in 8TeV uses jets after parton shower before hadronization.
This definition is useful to match with theory which uses cuts.f in madgraph.

**Discussion point: input particle definition**
Select quarks or gluons which does not decay/radidate to quarks or gluons - does this give consistent definition?
Note: other particles are ignored in this jet definition.

``` c++
    else if ( absPdgId < 6 or absPdgId == 21 )
    {
      // QCD particles : select one after parton shower, before hadronization
      bool toKeep = true;
      for ( size_t j=0, m=p.numberOfDaughters(); j<m; ++j )
      {
        const int absDauId = abs(p.daughter(j)->pdgId());
        if ( absDauId < 6 or absPdgId == 21 ) { toKeep = false; break; }
      }
      if ( toKeep )
      {
        qcdParticles.push_back(&p);
      }
    }
  }
```

**Discussion point 2 : 13TeV usage**
Will this be used in 13TeV analysis?
