### PR TITLE
Fix readme - git Clone from https, get correct tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ git cms-merge-topic cms-met:METCorUnc74X
 git clone git@github.com:cms-jet/JetToolbox.git JMEAnalysis/JetToolbox -b jetToolbox_74X
 git clone git@github.com:rfriese/RecoMET-METPUSubtraction RecoMET/METPUSubtraction/data -b 74X-13TeV-Summer15-July2015
 
-git clone git@github.com:vallot/CATTools.git -b v7-3-3
+git clone https://github.com/vallot/CATTools.git -n
+cd CATTools
+git co -b v733 v7-3-3
+cd ..
 
 cd CATTools
 git submodule init


### PR DESCRIPTION
git clone from https always works without ssh key setup.
This also protects direct commit to the central repo.

and git clone command does not work with -b TAG.
The recipe here retrieves HEAD version rather than v7-3-3.
