### PR TITLE
make catMET inherit from reco::Candidate

### DIFF
--- a/CommonTools/test/run_ntupleMaker_cfg.py
+++ b/CommonTools/test/run_ntupleMaker_cfg.py
@@ -14,7 +14,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 10000
 process.source = cms.Source("PoolSource",
       fileNames = cms.untracked.vstring(
 #'/store/user/youn/cat710_phy14_ttbar_2025_aod/catTuple_972.root'
-'file:catTuple.root'
+'file:catTuple_1.root'
 #'file:/cms/home/youn/work/cattool/tag711/cat/src/CATTools/CatProducer/prod/catTuple.root'
 #          '/store/user/jlee/TTJets_MSDecaysCKM_central_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/141219_091640/0000/catTuple_1.root',
 #          '/store/user/jlee/TTJets_MSDecaysCKM_central_Tune4C_13TeV-madgraph-tauola/Phys14DR-PU20bx25_PHYS14_25_V1-v1/141219_091640/0000/catTuple_2.root',

--- a/DataFormats/interface/MET.h
+++ b/DataFormats/interface/MET.h
@@ -17,26 +17,24 @@ namespace cat {
 
 namespace cat {
 
-  class MET {
+  class MET : public reco::LeafCandidate {
   public:
     typedef math::XYZTLorentzVector LorentzVector;
     
-    MET();
-    MET(float px, float py, float sumEt);
-    virtual ~MET();
+    MET() {};
+    MET(float px, float py, float sumEt) { set(px, py, sumEt); };
+    virtual ~MET() {};
 
-    void set(float px, float py, float sumEt) { px_ = px; py_ = py; sumEt_ = sumEt;}
+    void set(float px, float py, float sumEt) {
+      setP4(LorentzVector(px, py, 0, std::hypot(px, py)));
+      sumEt_ = sumEt;
+    }
 
     float sumEt() const { return sumEt_; }
-    float px() const { return px_; }
-    float py() const { return py_; }
-    float pt() const { return sqrt(px_*px_ + py_*py_); }
-    float phi() const { return px_ == 0.0 && py_ == 0.0 ? 0.0 : TMath::ATan2(py_,px_); }
-    TLorentzVector tlv() const {return TLorentzVector(px_, py_, 0.0, this->pt() );}
-    LorentzVector p4()  const {return LorentzVector(px_, py_, 0.0, this->pt() ) ;}
-  private:
+    TLorentzVector tlv() const {return TLorentzVector(px(), py(), 0.0, pt());}
 
-    float sumEt_, px_, py_;
+  private:
+    float sumEt_;
 
   };
 }

--- a/DataFormats/src/MET.cc
+++ b/DataFormats/src/MET.cc
@@ -1,15 +1,2 @@
 #include "CATTools/DataFormats/interface/MET.h"
 
-using namespace cat;
-
-/// default constructor
-MET::MET() {
-}
-
-MET::MET(float px, float py, float sumEt) {
-  px_ = px; py_ = py; sumEt_ = sumEt;
-}
-
-/// destructor
-MET::~MET() {
-}


### PR DESCRIPTION
Make catMETs to be inherited from the reco::LeafCandidate to use StringCutParser.
This is necessary for the GenericNtupleMaker. #144 
