### PR TITLE
Generator level dilepton analysis

### DIFF
--- a/CatAnalyzer/data/.gitignore
+++ b/CatAnalyzer/data/.gitignore
@@ -1,0 +1,2 @@
+dataset.json
+dataset_*.txt

--- a/CatAnalyzer/plugins/GenDileptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/GenDileptonAnalyzer.cc
@@ -1,0 +1,193 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CommonTools/Utils/interface/TFileDirectory.h"
+
+#include "TH1F.h"
+#include "TH2F.h"
+
+#include <iostream>
+
+using namespace std;
+
+class GenDileptonAnalyzer : public edm::EDAnalyzer
+{
+public:
+  GenDileptonAnalyzer(const edm::ParameterSet& pset);
+  void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
+
+private:
+  edm::EDGetTokenT<float> genWeightToken_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
+
+  TH1F* hZMass_, * hZDEta_, * hZDPhi_;
+  TH1F* hZPt_, * hZEta_, * hZPhi_;
+  TH1F* hL1Pt_, * hL1Eta_, * hL1Phi_;
+  TH1F* hL2Pt_, * hL2Eta_, * hL2Phi_;
+  TH1F* hLPPt_, * hLPEta_, * hLPPhi_;
+  TH1F* hLMPt_, * hLMEta_, * hLMPhi_;
+
+  TH1F* hNWZMass_, * hNWZDEta_, * hNWZDPhi_;
+  TH1F* hNWZPt_, * hNWZEta_, * hNWZPhi_;
+  TH1F* hNWL1Pt_, * hNWL1Eta_, * hNWL1Phi_;
+  TH1F* hNWL2Pt_, * hNWL2Eta_, * hNWL2Phi_;
+  TH1F* hNWLPPt_, * hNWLPEta_, * hNWLPPhi_;
+  TH1F* hNWLMPt_, * hNWLMEta_, * hNWLMPhi_;
+
+};
+
+//using namespace cat;
+
+GenDileptonAnalyzer::GenDileptonAnalyzer(const edm::ParameterSet& pset)
+{
+  genParticlesToken_ = consumes<reco::GenParticleCollection>(pset.getParameter<edm::InputTag>("src"));
+  genWeightToken_ = consumes<float>(pset.getParameter<edm::InputTag>("weight"));
+
+  edm::Service<TFileService> fs;
+ 
+  auto dirDefault = fs->mkdir("default");
+  hZMass_ = dirDefault.make<TH1F>("hZMass", "hZMass;M(l^{+}l^{-}) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hZDEta_ = dirDefault.make<TH1F>("hZDEta", "hZDEta;#delta#eta(l^{+},l^{-});Events per 0.05", 100, 0, 5);
+  hZDPhi_ = dirDefault.make<TH1F>("hZDPhi", "hZDPhi;#delta#phi(l^{+},l^{-}) (radian);Events per 0.01", 315, 0, 3.15);
+
+  hZPt_ = dirDefault.make<TH1F>("hZPt", "hZPt;p_{T}(l^{+}l^{-}) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hZEta_ = dirDefault.make<TH1F>("hZEta", "hZEta;#eta(l^{+}l^{-});Events per 0.05", 200, -5, 5);
+  hZPhi_ = dirDefault.make<TH1F>("hZPhi", "hZPhi;#phi(l^{+}l^{-}) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+
+  hL1Pt_ = dirDefault.make<TH1F>("hL1Pt", "hL1Pt;p_{T}(l, 1st. lead) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hL2Pt_ = dirDefault.make<TH1F>("hL2Pt", "hL2Pt;p_{T}(l, 2nd. lead) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hLPPt_ = dirDefault.make<TH1F>("hLPPt", "hL+Pt;p_{T}(l^{+}) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hLMPt_ = dirDefault.make<TH1F>("hLMPt", "hL-Pt;p_{T}(l^{-}) (GeV);Events per 1GeV", 1000, 0, 1000);
+
+  hL1Eta_ = dirDefault.make<TH1F>("hL1Eta", "hL1Eta;#eta(l, 1st. lead);Events per 0.05", 200, -5, 5);
+  hL2Eta_ = dirDefault.make<TH1F>("hL2Eta", "hL2Eta;#eta(l, 2nd. lead);Events per 0.05", 200, -5, 5);
+  hLPEta_ = dirDefault.make<TH1F>("hLPEta", "hL+Eta;#eta(l^{+});Events per 0.05", 200, -5, 5);
+  hLMEta_ = dirDefault.make<TH1F>("hLMEta", "hL-Eta;#eta(l^{-});Events per 0.05", 200, -5, 5);
+
+  hL1Phi_ = dirDefault.make<TH1F>("hL1Phi", "hL1Phi;#phi(l, 1st. lead) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+  hL2Phi_ = dirDefault.make<TH1F>("hL2Phi", "hL2Phi;#phi(l, 2nd. lead) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+  hLPPhi_ = dirDefault.make<TH1F>("hLPPhi", "hL+Phi;#phi(l^{+}) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+  hLMPhi_ = dirDefault.make<TH1F>("hLMPhi", "hL-Phi;#phi(l^{-}) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+
+  auto dirNW = fs->mkdir("noweight");
+  hNWZMass_ = dirNW.make<TH1F>("hZMass", "hZMass;M(l^{+}l^{-}) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hNWZDEta_ = dirNW.make<TH1F>("hZDEta", "hZDEta;#delta#eta(l^{+},l^{-});Events per 0.05", 100, 0, 5);
+  hNWZDPhi_ = dirNW.make<TH1F>("hZDPhi", "hZDPhi;#delta#phi(l^{+},l^{-}) (radian);Events per 0.01", 315, 0, 3.15);
+
+  hNWZPt_ = dirNW.make<TH1F>("hZPt", "hZPt;p_{T}(l^{+}l^{-}) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hNWZEta_ = dirNW.make<TH1F>("hZEta", "hZEta;#eta(l^{+}l^{-});Events per 0.05", 200, -5, 5);
+  hNWZPhi_ = dirNW.make<TH1F>("hZPhi", "hZPhi;#phi(l^{+}l^{-}) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+
+  hNWL1Pt_ = dirNW.make<TH1F>("hL1Pt", "hL1Pt;p_{T}(l, 1st. lead) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hNWL2Pt_ = dirNW.make<TH1F>("hL2Pt", "hL2Pt;p_{T}(l, 2nd. lead) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hNWLPPt_ = dirNW.make<TH1F>("hLPPt", "hL+Pt;p_{T}(l^{+}) (GeV);Events per 1GeV", 1000, 0, 1000);
+  hNWLMPt_ = dirNW.make<TH1F>("hLMPt", "hL-Pt;p_{T}(l^{-}) (GeV);Events per 1GeV", 1000, 0, 1000);
+
+  hNWL1Eta_ = dirNW.make<TH1F>("hL1Eta", "hL1Eta;#eta(l, 1st. lead);Events per 0.05", 200, -5, 5);
+  hNWL2Eta_ = dirNW.make<TH1F>("hL2Eta", "hL2Eta;#eta(l, 2nd. lead);Events per 0.05", 200, -5, 5);
+  hNWLPEta_ = dirNW.make<TH1F>("hLPEta", "hL+Eta;#eta(l^{+});Events per 0.05", 200, -5, 5);
+  hNWLMEta_ = dirNW.make<TH1F>("hLMEta", "hL-Eta;#eta(l^{-});Events per 0.05", 200, -5, 5);
+
+  hNWL1Phi_ = dirNW.make<TH1F>("hL1Phi", "hL1Phi;#phi(l, 1st. lead) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+  hNWL2Phi_ = dirNW.make<TH1F>("hL2Phi", "hL2Phi;#phi(l, 2nd. lead) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+  hNWLPPhi_ = dirNW.make<TH1F>("hLPPhi", "hL+Phi;#phi(l^{+}) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+  hNWLMPhi_ = dirNW.make<TH1F>("hLMPhi", "hL-Phi;#phi(l^{-}) (radian);Events per 0.01", 2*315, -3.15, 3.15);
+
+}
+
+void GenDileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
+{
+  edm::Handle<float> genWeightHandle;
+  event.getByToken(genWeightToken_, genWeightHandle);
+  const auto weight = *genWeightHandle == 0 ? 0 : *genWeightHandle/abs(*genWeightHandle);
+
+  edm::Handle<reco::GenParticleCollection> genParticlesHandle;
+  event.getByToken(genParticlesToken_, genParticlesHandle);
+
+  // Collect generator level leptons, before radiation 
+  typedef const reco::GenParticle* GenParticlePtr;
+  std::vector<GenParticlePtr> lepPs, lepMs;
+  for ( const auto& p : *genParticlesHandle )
+  {
+    if ( p.status() == 1 ) continue;
+    const int id = p.pdgId();
+    if ( p.numberOfMothers() > 0 and p.mother()->pdgId() == id ) continue;
+    const int absId = abs(id);
+
+    if ( absId != 11 and absId != 13 and absId != 15 ) continue;
+
+    if ( p.charge() > 0 ) lepPs.push_back(&p);
+    else lepMs.push_back(&p);
+  }
+  if ( lepPs.empty() or lepMs.empty() ) return;
+
+  auto greaterByPtPtr = [](GenParticlePtr a, GenParticlePtr b){return a->pt() > b->pt();};
+  std::nth_element(lepPs.begin(), lepPs.begin()+1, lepPs.end(), greaterByPtPtr);
+  std::nth_element(lepMs.begin(), lepMs.begin()+1, lepMs.end(), greaterByPtPtr);
+
+  const auto lepPLV = lepPs.at(0)->p4(), lepMLV = lepMs.at(0)->p4();
+  const auto lep1LV = lepPLV.pt() > lepMLV.pt() ? lepPLV : lepMLV;
+  const auto lep2LV = lepPLV.pt() > lepMLV.pt() ? lepMLV : lepPLV;
+  const auto zLV = lepPLV + lepMLV;
+  const double dEta = std::abs(lepPLV.eta()-lepMLV.eta());
+  const double dPhi = std::abs(reco::deltaPhi(lepPLV.phi(), lepMLV.phi()));
+
+  hZMass_->Fill(zLV.mass(), weight);
+  hZDEta_->Fill(dEta, weight);
+  hZDPhi_->Fill(dPhi, weight);
+
+  hZPt_->Fill(zLV.pt(), weight);
+  hZEta_->Fill(zLV.eta(), weight);
+  hZPhi_->Fill(zLV.phi(), weight);
+
+  hL1Pt_->Fill(lep1LV.pt(), weight);
+  hL1Eta_->Fill(lep1LV.eta(), weight);
+  hL1Phi_->Fill(lep1LV.phi(), weight);
+
+  hL2Pt_->Fill(lep2LV.pt(), weight);
+  hL2Eta_->Fill(lep2LV.eta(), weight);
+  hL2Phi_->Fill(lep2LV.phi(), weight);
+
+  hLPPt_->Fill(lepPLV.pt(), weight);
+  hLPEta_->Fill(lepPLV.eta(), weight);
+  hLPPhi_->Fill(lepPLV.phi(), weight);
+
+  hLMPt_->Fill(lepMLV.pt(), weight);
+  hLMEta_->Fill(lepMLV.eta(), weight);
+  hLMPhi_->Fill(lepMLV.phi(), weight);
+
+  hNWZMass_->Fill(zLV.mass());
+  hNWZDEta_->Fill(dEta);
+  hNWZDPhi_->Fill(dPhi);
+
+  hNWZPt_->Fill(zLV.pt());
+  hNWZEta_->Fill(zLV.eta());
+  hNWZPhi_->Fill(zLV.phi());
+
+  hNWL1Pt_->Fill(lep1LV.pt());
+  hNWL1Eta_->Fill(lep1LV.eta());
+  hNWL1Phi_->Fill(lep1LV.phi());
+
+  hNWL2Pt_->Fill(lep2LV.pt());
+  hNWL2Eta_->Fill(lep2LV.eta());
+  hNWL2Phi_->Fill(lep2LV.phi());
+
+  hNWLPPt_->Fill(lepPLV.pt());
+  hNWLPEta_->Fill(lepPLV.eta());
+  hNWLPPhi_->Fill(lepPLV.phi());
+
+  hNWLMPt_->Fill(lepMLV.pt());
+  hNWLMEta_->Fill(lepMLV.eta());
+  hNWLMPhi_->Fill(lepMLV.phi());
+}
+
+DEFINE_FWK_MODULE(GenDileptonAnalyzer);
+

--- a/CatAnalyzer/plugins/GenDileptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/GenDileptonAnalyzer.cc
@@ -123,6 +123,7 @@ void GenDileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup
     const int absId = abs(id);
 
     if ( absId != 11 and absId != 13 and absId != 15 ) continue;
+    if ( abs(p.mother()->pdgId()) == 15 ) continue;  //veto e/mu from tau.
 
     if ( p.charge() > 0 ) lepPs.push_back(&p);
     else lepMs.push_back(&p);

--- a/CatAnalyzer/test/GenLevel/run_DY_cfg.py
+++ b/CatAnalyzer/test/GenLevel/run_DY_cfg.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Ana")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("Configuration.StandardSequences.Services_cff")
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(True),
+    allowUnscheduled = cms.untracked.bool(True),
+)
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.MessageLogger.cerr.FwkReport.reportEvery = 10000
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
+process.source.fileNames = [
+  '/store/group/CAT/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v7-4-2_RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/150923_192710/0000/catTuple_1.root'
+]
+
+process.z = cms.EDAnalyzer("GenDileptonAnalyzer",
+    src = cms.InputTag("prunedGenParticles"),
+    weight = cms.InputTag("genWeight", "genWeight"),
+)
+
+process.p = cms.Path(process.z)
+
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string("hist.root"),
+)
+


### PR DESCRIPTION
An example generator level dilepton analysis code is added.
The analysis code produces generator level dilepton mass, pt, eta, phi and other useful distributions with find binning. (1GeV for mass and pt, 0.05 radian for phi, 0.01 for eta)

The generator level leptons are basically parton level objects - particles before radiation.

First usage of this analyzer is of course quick comparison in generator level.
But the main motivation to have this analyzer is calculating mass filter efficiency ( 20 < M < 50 ) in low mass Drell-Yan sample. The value will be then used to extrapolate cross section at > 20GeV to >10GeV samples.
