### PR TITLE
Generator level Analyzer module renaiming

### DIFF
--- a/CatAnalyzer/plugins/CATGenLeptonAnalysis.cc
+++ b/CatAnalyzer/plugins/CATGenLeptonAnalysis.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -18,10 +18,10 @@
 
 using namespace std;
 
-class GenDileptonAnalyzer : public edm::EDAnalyzer
+class CATGenLeptonAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources>
 {
 public:
-  GenDileptonAnalyzer(const edm::ParameterSet& pset);
+  CATGenLeptonAnalysis(const edm::ParameterSet& pset);
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
@@ -47,13 +47,12 @@ private:
 
 };
 
-//using namespace cat;
-
-GenDileptonAnalyzer::GenDileptonAnalyzer(const edm::ParameterSet& pset)
+CATGenLeptonAnalysis::CATGenLeptonAnalysis(const edm::ParameterSet& pset)
 {
   genParticlesToken_ = consumes<reco::GenParticleCollection>(pset.getParameter<edm::InputTag>("src"));
   genWeightToken_ = consumes<float>(pset.getParameter<edm::InputTag>("weight"));
 
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
  
   auto dirDefault = fs->mkdir("default");
@@ -110,7 +109,7 @@ GenDileptonAnalyzer::GenDileptonAnalyzer(const edm::ParameterSet& pset)
 
 }
 
-void GenDileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
+void CATGenLeptonAnalysis::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
 {
   edm::Handle<float> genWeightHandle;
   event.getByToken(genWeightToken_, genWeightHandle);
@@ -212,5 +211,5 @@ void GenDileptonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup
   }
 }
 
-DEFINE_FWK_MODULE(GenDileptonAnalyzer);
+DEFINE_FWK_MODULE(CATGenLeptonAnalysis);
 

--- a/CatAnalyzer/plugins/CATGenTopAnalysis.cc
+++ b/CatAnalyzer/plugins/CATGenTopAnalysis.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -20,10 +20,10 @@
 
 using namespace std;
 
-class CATGenLevelAnalysis : public edm::EDAnalyzer
+class CATGenTopAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources>
 {
 public:
-  CATGenLevelAnalysis(const edm::ParameterSet& pset);
+  CATGenTopAnalysis(const edm::ParameterSet& pset);
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
@@ -33,14 +33,14 @@ private:
   edm::EDGetTokenT<reco::GenParticleCollection> pseudoTopToken_;
 
   typedef const reco::Candidate* CCandPtr;
-  bool isAcceptedFullLept(CCandPtr l1, CCandPtr l2, CCandPtr b1, CCandPtr b2) {
+  bool isAcceptedFullLept(CCandPtr l1, CCandPtr l2, CCandPtr b1, CCandPtr b2) const {
     if ( l1->pt() < 20 or std::abs(l1->eta()) > 2.4 ) return false;
     if ( l2->pt() < 20 or std::abs(l2->eta()) > 2.4 ) return false;
     if ( b1->pt() < 30 or std::abs(b1->eta()) > 2.4 ) return false;
     if ( b2->pt() < 30 or std::abs(b2->eta()) > 2.4 ) return false;
     return true;
   }
-  bool isAcceptedSemiLept(CCandPtr lep, CCandPtr q1, CCandPtr q2, CCandPtr b1, CCandPtr b2) {
+  bool isAcceptedSemiLept(CCandPtr lep, CCandPtr q1, CCandPtr q2, CCandPtr b1, CCandPtr b2) const {
     if ( lep->pt() < 30 or std::abs(lep->eta()) > 2.4 ) return false;
     if ( q1->pt() < 30 or std::abs(q1->eta()) > 2.4 ) return false;
     if ( q2->pt() < 30 or std::abs(q2->eta()) > 2.4 ) return false;
@@ -75,15 +75,14 @@ private:
   std::vector<TH2F*> h2_, h2Com_;
 };
 
-//using namespace cat;
-
-CATGenLevelAnalysis::CATGenLevelAnalysis(const edm::ParameterSet& pset)
+CATGenTopAnalysis::CATGenTopAnalysis(const edm::ParameterSet& pset)
 {
   partonTopToken_ = consumes<reco::GenParticleCollection>(pset.getParameter<edm::InputTag>("partonTop"));
   pseudoTopToken_ = consumes<reco::GenParticleCollection>(pset.getParameter<edm::InputTag>("pseudoTop"));
   channelToken_ = consumes<int>(pset.getParameter<edm::InputTag>("channel"));
   modesToken_ = consumes<std::vector<int> >(pset.getParameter<edm::InputTag>("modes"));
 
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
 
   const std::vector<std::vector<float> > bins = {
@@ -165,7 +164,7 @@ CATGenLevelAnalysis::CATGenLevelAnalysis(const edm::ParameterSet& pset)
 
 }
 
-void CATGenLevelAnalysis::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
+void CATGenTopAnalysis::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
 {
   edm::Handle<int> channelHandle;
   event.getByToken(channelToken_, channelHandle);
@@ -438,5 +437,5 @@ void CATGenLevelAnalysis::analyze(const edm::Event& event, const edm::EventSetup
 
 }
 
-DEFINE_FWK_MODULE(CATGenLevelAnalysis);
+DEFINE_FWK_MODULE(CATGenTopAnalysis);
 

--- a/CatAnalyzer/plugins/CATHisAnalysis.cc
+++ b/CatAnalyzer/plugins/CATHisAnalysis.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 
@@ -33,7 +33,7 @@ using namespace std;
 //
 // class decleration
 //
-class CATHisAnalysis : public edm::EDAnalyzer {
+class CATHisAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources> {
   public:
     explicit CATHisAnalysis(const edm::ParameterSet & pset);
     ~CATHisAnalysis() {};
@@ -117,6 +117,7 @@ CATHisAnalysis::CATHisAnalysis(const edm::ParameterSet& pset )
   photonToken_   = consumes<edm::View<TPhoton> >(pset.getParameter<edm::InputTag>("photons"));
   tauToken_      = consumes<edm::View<TTau> >(pset.getParameter<edm::InputTag>("taus"));
 
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
 
   TFileDirectory dirElectron = fs->mkdir("electron", "electron");

--- a/CatAnalyzer/plugins/CATMuonAnalysis.cc
+++ b/CatAnalyzer/plugins/CATMuonAnalysis.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,15 +31,13 @@ using namespace std;
 //
 // class decleration
 //
-class CATMuonAnalysis : public edm::EDAnalyzer {
+class CATMuonAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources> {
   public:
     explicit CATMuonAnalysis(const edm::ParameterSet&);
     ~CATMuonAnalysis();
 
   private:
-    virtual void beginJob() ;
-    virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endJob() ;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
     // ----------member data ---------------------------
 
@@ -58,6 +56,7 @@ class CATMuonAnalysis : public edm::EDAnalyzer {
 CATMuonAnalysis::CATMuonAnalysis(const edm::ParameterSet& iConfig):
   src_(consumes<edm::View<cat::Muon> >(iConfig.getParameter<edm::InputTag>("src")))
 {
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
   
   phi   = fs->make<TH1F>("phi","phi",400,0,4);
@@ -74,14 +73,6 @@ CATMuonAnalysis::~CATMuonAnalysis()
 {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-
-}
-
-void CATMuonAnalysis::beginJob(){
-  //Add event and RUN BRANCHING         
-}
-
-void CATMuonAnalysis::endJob(){
 
 }
 

--- a/CatAnalyzer/test/GenLevel/run_DY_cfg.py
+++ b/CatAnalyzer/test/GenLevel/run_DY_cfg.py
@@ -16,7 +16,7 @@ process.source.fileNames = [
   '/store/group/CAT/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v7-4-2_RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/150923_192710/0000/catTuple_1.root'
 ]
 
-process.z = cms.EDAnalyzer("GenDileptonAnalyzer",
+process.z = cms.EDAnalyzer("CATGenLeptonAnalysis",
     src = cms.InputTag("prunedGenParticles"),
     weight = cms.InputTag("genWeight", "genWeight"),
 )

--- a/CatAnalyzer/test/GenLevel/run_genLevel_cfg.py
+++ b/CatAnalyzer/test/GenLevel/run_genLevel_cfg.py
@@ -44,7 +44,7 @@ process.partonTop = cms.EDProducer("PartonTopProducer",
     jetMinPt = cms.double(20)
 )
 
-process.ana = cms.EDAnalyzer("CATGenLevelAnalysis",
+process.ana = cms.EDAnalyzer("CATGenTopAnalysis",
     channel = cms.InputTag("partonTop","channel"),
     modes = cms.InputTag("partonTop", "modes"),
     partonTop = cms.InputTag("partonTop"),


### PR DESCRIPTION
Generator level analyzer modules are renamed.
Changed to inherit from edm::one::EDAnalyzer to be mult-threading compatible.
