### PR TITLE
Re-categorize tau leptonic channel into leptonic "channel"

### DIFF
--- a/CatProducer/plugins/PartonTopProducer.cc
+++ b/CatProducer/plugins/PartonTopProducer.cc
@@ -219,8 +219,14 @@ void PartonTopProducer::produce(edm::Event& event, const edm::EventSetup& eventS
         if ( lepFromTau )
         {
           ++nTauToLepton;
-          if ( abs(lepFromTau->pdgId()) == 13 ) mode += 1;
-          else mode += 2;
+          if ( abs(lepFromTau->pdgId()) == 13 ) {
+            mode += 1;
+            ++nMuon;
+          }
+          else {
+            mode += 2;
+            ++nElectron;
+          }
         }
         break;
     }


### PR DESCRIPTION
The "channel" from partonTopProducer was (mis)treading tau leptonic channel as hadronic.

Previously, tau channels including lepton decay were included in the hadronic channel. Now this is moved to semi-leptonic or dileptonic channels depending on number of final state leptons.
