### PR TITLE
Rescale genWeight by unity with sign

### DIFF
--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -27,7 +27,7 @@ public:
   void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
-  const bool scaleGenWeight_;
+  const bool enforceUnitGenWeight_;
   bool doReweightPdf_;
   const std::string pdfName_;
   std::string generatedPdfName_;
@@ -37,7 +37,7 @@ private:
 };
 
 GenWeightsProducer::GenWeightsProducer(const edm::ParameterSet& pset):
-  scaleGenWeight_(pset.getParameter<bool>("scaleGenWeight")),
+  enforceUnitGenWeight_(pset.getParameter<bool>("enforceUnitGenWeight")),
   pdfName_(pset.getParameter<std::string>("pdfName")),
   lheToken_(consumes<LHEEventProduct>(pset.getParameter<edm::InputTag>("lheEvent"))),
   genInfoToken_(consumes<GenEventInfoProduct>(pset.getParameter<edm::InputTag>("genEventInfo"))),
@@ -78,14 +78,27 @@ void GenWeightsProducer::produce(edm::Event& event, const edm::EventSetup& event
 
   edm::Handle<LHEEventProduct> lheHandle;
   event.getByToken(lheToken_, lheHandle);
-
   edm::Handle<GenEventInfoProduct> genInfoHandle;
   event.getByToken(genInfoToken_, genInfoHandle);
 
-  if ( lheHandle.isValid() and lheHandle->weights().size() > lheWeightIndex_ ) lheWeight = lheHandle->weights().at(lheWeightIndex_).wgt;
+  // Generator weights
+  //   enforceUnitGenWeight == true  : genWeights are scaled to +1 or -1 by themselves
+  //   enforceUnitGenWeight == false : genWeights are scaled by 1/originalWeight.
+  //                                   do not scale weight if LHE is not available.
+  double originalWeight = 1;
+  if ( lheHandle.isValid() and lheHandle->weights().size() > lheWeightIndex_ ) {
+    lheWeight = lheHandle->weights().at(lheWeightIndex_).wgt;
+    originalWeight = std::abs(lheHandle->originalXWGTUP());
+  }
   if ( genInfoHandle->weights().size() > genWeightIndex_ ) genWeight = genInfoHandle->weights().at(genWeightIndex_);
-  lheWeight = lheWeight == 0 ? 0 : lheWeight/std::abs(lheWeight);
-  genWeight = genWeight == 0 ? 0 : genWeight/std::abs(genWeight);
+  if ( enforceUnitGenWeight_ ) {
+    lheWeight = lheWeight == 0 ? 0 : lheWeight/std::abs(lheWeight);
+    genWeight = genWeight == 0 ? 0 : genWeight/std::abs(genWeight);
+  }
+  else {
+    lheWeight = originalWeight == 0 ? 0 : lheWeight/originalWeight;
+    genWeight = originalWeight == 0 ? 0 : genWeight/originalWeight;
+  }
 
   const float q = genInfoHandle->pdf()->scalePDF;
   const int id1 = genInfoHandle->pdf()->id.first;

--- a/CatProducer/python/genWeight_cff.py
+++ b/CatProducer/python/genWeight_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 genWeight = cms.EDProducer("GenWeightsProducer",
-    scaleGenWeight = cms.bool(True),
+    enforceUnitGenWeight = cms.bool(False),
     lheEvent = cms.InputTag("externalLHEProducer"),
     genEventInfo = cms.InputTag("generator"),
     pdfName = cms.string("NNPDF30_nlo_as_0118"),

--- a/CatProducer/python/genWeight_cff.py
+++ b/CatProducer/python/genWeight_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 genWeight = cms.EDProducer("GenWeightsProducer",
+    scaleGenWeight = cms.bool(True),
     lheEvent = cms.InputTag("externalLHEProducer"),
     genEventInfo = cms.InputTag("generator"),
     pdfName = cms.string("NNPDF30_nlo_as_0118"),


### PR DESCRIPTION
genWeight and LHEWeights in some samples have some very large arbitrary value, say 6345.28.
Weight values are expected to be +1 or -1, so it's worth to rescale them.
