### PR TITLE
Use r-value reference syntax

### DIFF
--- a/CatAnalyzer/plugins/CATGenLeptonAnalysis.cc
+++ b/CatAnalyzer/plugins/CATGenLeptonAnalysis.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -9,7 +8,6 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "CommonTools/Utils/interface/TFileDirectory.h"
 
 #include "TH1F.h"
 #include "TH2F.h"

--- a/CatAnalyzer/plugins/CATGenTopAnalysis.cc
+++ b/CatAnalyzer/plugins/CATGenTopAnalysis.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -9,10 +8,8 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "CommonTools/Utils/interface/TFileDirectory.h"
 
 #include "Math/GenVector/Boost.h"
-#include "TH1.h"
 #include "TH1F.h"
 #include "TH2F.h"
 

--- a/CatAnalyzer/plugins/CATHisAnalysis.cc
+++ b/CatAnalyzer/plugins/CATHisAnalysis.cc
@@ -1,4 +1,3 @@
-// user include files
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/CatAnalyzer/plugins/CATHisAnalysis.cc
+++ b/CatAnalyzer/plugins/CATHisAnalysis.cc
@@ -35,22 +35,15 @@ class CATHisAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 
   private:
 
-    // ----------member data ---------------------------
-    typedef cat::Electron TElectron;
     typedef cat::GenJet TGenJet;
-    typedef cat::Jet TJet;
-    typedef cat::MET TMET;
-    typedef cat::Muon TMuon;
-    typedef cat::Photon TPhoton;
-    typedef cat::Tau TTau;
 
-    edm::EDGetTokenT<edm::View<TElectron> > electronToken_;
-    edm::EDGetTokenT<edm::View<TGenJet> > genjetToken_;
-    edm::EDGetTokenT<edm::View<TJet> > jetToken_;
-    edm::EDGetTokenT<edm::View<TMET> > metToken_;
-    edm::EDGetTokenT<edm::View<TMuon> > muonToken_;
-    edm::EDGetTokenT<edm::View<TPhoton> > photonToken_;
-    edm::EDGetTokenT<edm::View<TTau> > tauToken_;
+    edm::EDGetTokenT<cat::ElectronCollection> electronToken_;
+    edm::EDGetTokenT<cat::GenJetCollection> genjetToken_;
+    edm::EDGetTokenT<cat::JetCollection> jetToken_;
+    edm::EDGetTokenT<cat::METCollection> metToken_;
+    edm::EDGetTokenT<cat::MuonCollection> muonToken_;
+    edm::EDGetTokenT<cat::PhotonCollection> photonToken_;
+    edm::EDGetTokenT<cat::TauCollection> tauToken_;
 
     TH1F* hElectron_phi_;
     TH1F* hElectron_eta_;
@@ -103,13 +96,13 @@ class CATHisAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 
 CATHisAnalysis::CATHisAnalysis(const edm::ParameterSet& pset )
 {
-  electronToken_ = consumes<edm::View<TElectron> >(pset.getParameter<edm::InputTag>("electrons"));
-  genjetToken_   = consumes<edm::View<TGenJet> >(pset.getParameter<edm::InputTag>("genjets"));
-  jetToken_      = consumes<edm::View<TJet> >(pset.getParameter<edm::InputTag>("jets"));
-  metToken_      = consumes<edm::View<TMET> >(pset.getParameter<edm::InputTag>("mets"));
-  muonToken_     = consumes<edm::View<TMuon> >(pset.getParameter<edm::InputTag>("muons"));
-  photonToken_   = consumes<edm::View<TPhoton> >(pset.getParameter<edm::InputTag>("photons"));
-  tauToken_      = consumes<edm::View<TTau> >(pset.getParameter<edm::InputTag>("taus"));
+  electronToken_ = consumes<cat::ElectronCollection>(pset.getParameter<edm::InputTag>("electrons"));
+  genjetToken_   = consumes<cat::GenJetCollection>(pset.getParameter<edm::InputTag>("genjets"));
+  jetToken_      = consumes<cat::JetCollection>(pset.getParameter<edm::InputTag>("jets"));
+  metToken_      = consumes<cat::METCollection>(pset.getParameter<edm::InputTag>("mets"));
+  muonToken_     = consumes<cat::MuonCollection>(pset.getParameter<edm::InputTag>("muons"));
+  photonToken_   = consumes<cat::PhotonCollection>(pset.getParameter<edm::InputTag>("photons"));
+  tauToken_      = consumes<cat::TauCollection>(pset.getParameter<edm::InputTag>("taus"));
 
   usesResource("TFileService");
   edm::Service<TFileService> fs;
@@ -176,7 +169,7 @@ void CATHisAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup&)
   using namespace std;
   using namespace reco;
 
-  edm::Handle<edm::View<TElectron> > electronHandle;
+  edm::Handle<cat::ElectronCollection> electronHandle;
   iEvent.getByToken(electronToken_,electronHandle);
   for ( int i=0, n=electronHandle->size(); i<n; ++i )
   {
@@ -192,7 +185,7 @@ void CATHisAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup&)
     hElectron_puIso_->Fill( electron.puChargedHadronIso() );
   }
 
-  edm::Handle<edm::View<TGenJet> > genjetHandle;
+  edm::Handle<cat::GenJetCollection> genjetHandle;
   iEvent.getByToken(genjetToken_,genjetHandle);
   for ( int i=0, n=genjetHandle->size(); i<n; ++i )
   {
@@ -204,7 +197,7 @@ void CATHisAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup&)
     hGenJet_mass_ ->Fill( genjet.mass() );
   }
 
-  edm::Handle<edm::View<TJet> > jetHandle;
+  edm::Handle<cat::JetCollection> jetHandle;
   iEvent.getByToken(jetToken_,jetHandle);
   for ( int i=0, n=jetHandle->size(); i<n; ++i )
   {
@@ -216,7 +209,7 @@ void CATHisAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup&)
     hJet_mass_ ->Fill( jet.mass() );
   }
 
-  edm::Handle<edm::View<TMET> > metHandle;
+  edm::Handle<cat::METCollection> metHandle;
   iEvent.getByToken(metToken_,metHandle);
   for ( int i=0, n=metHandle->size(); i<n; ++i )
   {
@@ -228,7 +221,7 @@ void CATHisAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup&)
     //hMet_mass_ ->Fill( met.mass() );
   }
 
-  edm::Handle<edm::View<TMuon> > muonHandle;
+  edm::Handle<cat::MuonCollection> muonHandle;
   iEvent.getByToken(muonToken_,muonHandle);
   for ( int i=0, n=muonHandle->size(); i<n; ++i )
   {
@@ -244,7 +237,7 @@ void CATHisAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup&)
     hMuon_puIso_->Fill( muon.puChargedHadronIso() );
   }
 
-  edm::Handle<edm::View<TPhoton> > photonHandle;
+  edm::Handle<cat::PhotonCollection> photonHandle;
   iEvent.getByToken(photonToken_,photonHandle);
   for ( int i=0, n=photonHandle->size(); i<n; ++i )
   {
@@ -260,7 +253,7 @@ void CATHisAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup&)
     hPhoton_puIso_->Fill( photon.puChargedHadronIso() );
   }
 
-  edm::Handle<edm::View<TTau> > tauHandle;
+  edm::Handle<cat::TauCollection> tauHandle;
   iEvent.getByToken(tauToken_,tauHandle);
   for ( int i=0, n=tauHandle->size(); i<n; ++i )
   {

--- a/CatAnalyzer/plugins/CATHisAnalysis.cc
+++ b/CatAnalyzer/plugins/CATHisAnalysis.cc
@@ -1,8 +1,4 @@
-// system include files
-#include <memory>
-
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -22,7 +18,6 @@
 #include "CATTools/DataFormats/interface/Tau.h"
 
 #include "TH1F.h"
-#include "TFile.h"
 #include "TTree.h"
 
 void analyze()

--- a/CatAnalyzer/plugins/CATMuonAnalysis.cc
+++ b/CatAnalyzer/plugins/CATMuonAnalysis.cc
@@ -1,4 +1,3 @@
-// user include files
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/CatAnalyzer/plugins/CATMuonAnalysis.cc
+++ b/CatAnalyzer/plugins/CATMuonAnalysis.cc
@@ -35,7 +35,7 @@ class CATMuonAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 
     // ----------member data ---------------------------
 
-    edm::EDGetTokenT<edm::View<cat::Muon> > src_;
+    edm::EDGetTokenT<cat::MuonCollection> src_;
 
     TH1F* phi;
     TH1F* eta;
@@ -48,7 +48,7 @@ class CATMuonAnalysis : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 };
 
 CATMuonAnalysis::CATMuonAnalysis(const edm::ParameterSet& iConfig):
-  src_(consumes<edm::View<cat::Muon> >(iConfig.getParameter<edm::InputTag>("src")))
+  src_(consumes<cat::MuonCollection>(iConfig.getParameter<edm::InputTag>("src")))
 {
   usesResource("TFileService");
   edm::Service<TFileService> fs;
@@ -76,7 +76,7 @@ void CATMuonAnalysis::analyze( const edm::Event& iEvent, const edm::EventSetup& 
   using namespace std;
   using namespace reco;
 
-  Handle<View<cat::Muon> > src;
+  Handle<cat::MuonCollection> src;
   iEvent.getByToken(src_, src);
 
   for (unsigned int i = 0; i < src->size() ; i++) {

--- a/CatAnalyzer/plugins/CATMuonAnalysis.cc
+++ b/CatAnalyzer/plugins/CATMuonAnalysis.cc
@@ -1,8 +1,4 @@
-// system include files
-#include <memory>
-
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -24,7 +20,6 @@
 #include "DataFormats/PatCandidates/interface/LookupTableRecord.h"
 
 #include "TH1F.h"
-#include "TFile.h"
 #include "TTree.h"
 
 using namespace std;

--- a/CatAnalyzer/plugins/CATTriggerBitCombiner.cc
+++ b/CatAnalyzer/plugins/CATTriggerBitCombiner.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -154,7 +154,7 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
 
     sort(seljets.begin(), seljets.end(), cat::GtByTLVPt);
 
-    b_nVtx = vtx->at(0);
+    b_nVtx = *vtx;
     b_nJet = seljets.size();
 
     int hlt_count = 0;

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -31,9 +31,8 @@ class ColorCoherenceAnalyzer : public edm::EDAnalyzer{
 public:
   explicit ColorCoherenceAnalyzer(const edm::ParameterSet&); 
   ~ColorCoherenceAnalyzer();
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   enum sys_e {sys_nom, sys_jes_u, sys_jes_d, sys_jer_u, sys_jer_d, sys_jar, nsys_e};
+  enum sys_e {sys_nom, sys_jes_u, sys_jes_d, sys_jer_u, sys_jer_d, sys_jar, nsys_e};
  
 private:
 
@@ -156,7 +155,7 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
   for (int sys = 0; sys < nsys_e; ++sys){
     resetBr();
     
-    vector<TLorentzVector> seljets = selectJets(jets.product(), (sys_e)sys);
+    vector<TLorentzVector>&& seljets = selectJets(jets.product(), (sys_e)sys);
     if (seljets.size() < 3) return;
 
     sort(seljets.begin(), seljets.end(), cat::GtByTLVPt);
@@ -245,12 +244,4 @@ void ColorCoherenceAnalyzer::resetBr()
   b_gjet3_pt = -99; b_gjet3_eta = -99; b_gjet3_phi = -99;
 }
 
-void ColorCoherenceAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
-{
-  //The following says we do not know what parameters are allowed so do no validation
-  //  // Please change this to state exactly what you do use, even if it is no parameters
-  edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
-}
 DEFINE_FWK_MODULE(ColorCoherenceAnalyzer);

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -1,6 +1,3 @@
-#include <memory>
-
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -9,7 +6,6 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "CommonTools/Utils/interface/PtComparator.h"
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
@@ -24,7 +20,6 @@
 
 #include "TString.h"
 #include "TTree.h"
-#include "TFile.h"
 #include "TLorentzVector.h"
 #include "Math/PtEtaPhiM4D.h"
 

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -181,6 +181,8 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
     b_jet1_pt = seljets[0].Pt(); b_jet1_eta = seljets[0].Eta(); b_jet1_phi = seljets[0].Phi();
     b_jet2_pt = seljets[1].Pt(); b_jet2_eta = seljets[1].Eta(); b_jet2_phi = seljets[1].Phi();
     b_jet3_pt = seljets[2].Pt(); b_jet3_eta = seljets[2].Eta(); b_jet3_phi = seljets[2].Phi();
+
+    // TODO: MET uncertainty due to jet energy scale to be added!!!
     b_met = mets->begin()->et();
     b_metSig = mets->begin()->et()/mets->begin()->sumEt();
     ttree_[sys]->Fill();

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +26,7 @@
 #include <cmath>
 using namespace std;
 
-class ColorCoherenceAnalyzer : public edm::EDAnalyzer{
+class ColorCoherenceAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit ColorCoherenceAnalyzer(const edm::ParameterSet&);
   ~ColorCoherenceAnalyzer() {};
@@ -73,6 +73,7 @@ ColorCoherenceAnalyzer::ColorCoherenceAnalyzer(const edm::ParameterSet& iConfig)
   triggerBits_ = consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerBits"));
   triggerObjects_ = consumes<pat::TriggerObjectStandAloneCollection>(iConfig.getParameter<edm::InputTag>("triggerObjects"));
 
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
   const std::vector<std::string> sys_name = {"nom", "jes_u", "jes_d", "jer_u", "jer_d", "jar"};
   for (auto sys : sys_name) {

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -30,7 +30,7 @@ using namespace std;
 class ColorCoherenceAnalyzer : public edm::EDAnalyzer{
 public:
   explicit ColorCoherenceAnalyzer(const edm::ParameterSet&); 
-  ~ColorCoherenceAnalyzer();
+  ~ColorCoherenceAnalyzer() {};
 
   enum sys_e {sys_nom, sys_jes_u, sys_jes_d, sys_jer_u, sys_jer_d, sys_jar, nsys_e};
  
@@ -38,9 +38,9 @@ private:
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   void resetBr();
-  vector<TLorentzVector> selectJets(const edm::View<cat::Jet>* jets, sys_e sys);
-  TLorentzVector sysJet(cat::Jet, sys_e sys);
-  TLorentzVector jarJet(cat::Jet jet);
+  vector<TLorentzVector> selectJets(const edm::View<cat::Jet>* jets, sys_e sys) const;
+  TLorentzVector sysJet(cat::Jet, sys_e sys) const;
+  TLorentzVector jarJet(cat::Jet jet) const;
 
   edm::EDGetTokenT<edm::View<cat::Jet> >      jetToken_;
   edm::EDGetTokenT<edm::View<cat::MET> >      metToken_;
@@ -127,7 +127,6 @@ ColorCoherenceAnalyzer::ColorCoherenceAnalyzer(const edm::ParameterSet& iConfig)
   }   
   
 }
-ColorCoherenceAnalyzer::~ColorCoherenceAnalyzer(){}
 
 void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
@@ -194,7 +193,7 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
   }
 }
 
-vector<TLorentzVector> ColorCoherenceAnalyzer::selectJets(const edm::View<cat::Jet>* jets, sys_e sys)
+vector<TLorentzVector> ColorCoherenceAnalyzer::selectJets(const edm::View<cat::Jet>* jets, sys_e sys) const
 {
   vector<TLorentzVector> seljets;
   for (auto jet : *jets) {
@@ -208,7 +207,7 @@ vector<TLorentzVector> ColorCoherenceAnalyzer::selectJets(const edm::View<cat::J
   return seljets;
 }
 
-TLorentzVector ColorCoherenceAnalyzer::sysJet(cat::Jet jet, sys_e sys)
+TLorentzVector ColorCoherenceAnalyzer::sysJet(cat::Jet jet, sys_e sys) const
 {
   if (sys == sys_nom) return jet.tlv();
   if (sys == sys_jes_u) return jet.tlv()*jet.shiftedEnUp();
@@ -220,7 +219,7 @@ TLorentzVector ColorCoherenceAnalyzer::sysJet(cat::Jet jet, sys_e sys)
   return jet.tlv();
 }
 
-TLorentzVector ColorCoherenceAnalyzer::jarJet(cat::Jet jet)
+TLorentzVector ColorCoherenceAnalyzer::jarJet(cat::Jet jet) const
 {
   // temp... currently doing NOTHING
   TLorentzVector sJet;

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -28,11 +28,11 @@ using namespace std;
 
 class ColorCoherenceAnalyzer : public edm::EDAnalyzer{
 public:
-  explicit ColorCoherenceAnalyzer(const edm::ParameterSet&); 
+  explicit ColorCoherenceAnalyzer(const edm::ParameterSet&);
   ~ColorCoherenceAnalyzer() {};
 
   enum sys_e {sys_nom, sys_jes_u, sys_jes_d, sys_jer_u, sys_jer_d, sys_jar, nsys_e};
- 
+
 private:
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -120,8 +120,8 @@ ColorCoherenceAnalyzer::ColorCoherenceAnalyzer(const edm::ParameterSet& iConfig)
     tr->Branch("gdel_eta", &b_gdel_eta, "gdel_eta/F");
     tr->Branch("gdel_phi", &b_gdel_phi, "gdel_phi/F");
     tr->Branch("gdel_r", &b_gdel_r, "gdel_r/F");
-  }   
-  
+  }
+
 }
 
 void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
@@ -144,11 +144,11 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
   iEvent.getByToken(triggerObjects_, triggerObjects);
 
   const edm::TriggerNames &triggerNames = iEvent.triggerNames(*triggerBits);
-  cat::AnalysisHelper trigHelper = cat::AnalysisHelper(triggerNames, triggerBits, triggerObjects); 
+  cat::AnalysisHelper trigHelper = cat::AnalysisHelper(triggerNames, triggerBits, triggerObjects);
 
   for (int sys = 0; sys < nsys_e; ++sys){
     resetBr();
-    
+
     vector<TLorentzVector>&& seljets = selectJets(jets.product(), (sys_e)sys);
     if (seljets.size() < 3) return;
 
@@ -156,21 +156,21 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
 
     b_nVtx = vtx->at(0);
     b_nJet = seljets.size();
-    
+
     int hlt_count = 0;
     //trigHelper.listFiredTriggers();
     if(trigHelper.triggerFired("HLT_PAJet40_NoJetID_v")) {b_hlt_40_pass = 1; hlt_count++;}
     if(trigHelper.triggerFired("HLT_PAJet60_NoJetID_v")) {b_hlt_60_pass = 1; hlt_count++;}
     if(trigHelper.triggerFired("HLT_PAJet80_NoJetID_v")) {b_hlt_80_pass = 1; hlt_count++;}
-    
+
     if(trigHelper.triggerFired("HLT_PFJet80_v")) {b_hlt_80_pass = 1; hlt_count++;}// dont u use pfjet80 too?
-    if(trigHelper.triggerFired("HLT_PFJet140_v")) {b_hlt_140_pass = 1; hlt_count++;}  
+    if(trigHelper.triggerFired("HLT_PFJet140_v")) {b_hlt_140_pass = 1; hlt_count++;}
     if(trigHelper.triggerFired("HLT_PFJet320_v")) {b_hlt_320_pass = 1; hlt_count++;}
     if(trigHelper.triggerFired("HLT_PFJet400_v")) {b_hlt_400_pass = 1; hlt_count++;}
     if(trigHelper.triggerFired("HLT_PFJet450_v")) {b_hlt_450_pass = 1; hlt_count++;}
     if(trigHelper.triggerFired("HLT_PFJet500_v")) {b_hlt_500_pass = 1; hlt_count++;}
     //if (hlt_count < 1) return;
-    
+
     b_del_eta = copysign(1.0, seljets[1].Eta())*(seljets[2].Eta() - seljets[1].Eta());
     b_del_phi = reco::deltaPhi(seljets[2].Phi(), seljets[1].Phi());
     b_beta = atan2(b_del_phi, b_del_eta);
@@ -196,9 +196,9 @@ vector<TLorentzVector> ColorCoherenceAnalyzer::selectJets(const edm::View<cat::J
   for (auto jet : *jets) {
     if (!jet.LooseId()) continue;
     if (jet.pileupJetId() <0.9) continue;
-    TLorentzVector newjet = sysJet(jet, sys);    
+    TLorentzVector newjet = sysJet(jet, sys);
     if (newjet.Pt() <= 20.) continue;
-    
+
     seljets.push_back(newjet);
   }
   return seljets;
@@ -212,7 +212,7 @@ TLorentzVector ColorCoherenceAnalyzer::sysJet(cat::Jet jet, sys_e sys) const
   if (sys == sys_jer_u) return jet.tlv()*jet.smearedResUp();
   if (sys == sys_jer_d) return jet.tlv()*jet.smearedResDown();
   if (sys == sys_jar) return jarJet(jet);
-  
+
   return jet.tlv();
 }
 

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -154,7 +154,7 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
 
     sort(seljets.begin(), seljets.end(), cat::GtByTLVPt);
 
-    b_nVtx = vtx.product()[0];
+    b_nVtx = vtx->at(0);
     b_nJet = seljets.size();
     
     int hlt_count = 0;

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -18,7 +18,6 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-#include "TString.h"
 #include "TTree.h"
 #include "TLorentzVector.h"
 #include "Math/PtEtaPhiM4D.h"
@@ -49,7 +48,6 @@ private:
   edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjects_;
 
   vector<TTree*> ttree_;
-  vector<TString> sys_name;
 
   int b_nVtx, b_nJet, b_hlt_40_pass, b_hlt_60_pass, b_hlt_80_pass, b_hlt_140_pass, b_hlt_320_pass, b_hlt_400_pass, b_hlt_450_pass, b_hlt_500_pass;
   float b_beta, b_del_eta, b_del_phi, b_del_r;
@@ -76,12 +74,10 @@ ColorCoherenceAnalyzer::ColorCoherenceAnalyzer(const edm::ParameterSet& iConfig)
   triggerObjects_ = consumes<pat::TriggerObjectStandAloneCollection>(iConfig.getParameter<edm::InputTag>("triggerObjects"));
 
   edm::Service<TFileService> fs;
-  sys_name = {"nom", "jes_u", "jes_d", "jer_u", "jer_d", "jar"};
+  const std::vector<std::string> sys_name = {"nom", "jes_u", "jes_d", "jer_u", "jer_d", "jar"};
   for (auto sys : sys_name) {
-    ttree_.push_back(fs->make<TTree>(sys, "color cohernece systematic errors : "+sys));
-  }
-  for (auto tr : ttree_) {
-    TString sys = TString(tr->GetName())+"_";
+    ttree_.push_back(fs->make<TTree>(sys.c_str(), (string("color cohernece systematic errors : ")+sys).c_str()));
+    auto tr = ttree_.back();
 
     tr->Branch("nvtx", &b_nVtx, "nvtx/I");
     tr->Branch("njet", &b_nJet, "njet/I");

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -129,7 +129,6 @@ void ColorCoherenceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
   runOnMC_ = !iEvent.isRealData();
 
   edm::Handle<edm::View<cat::Jet> > jets;
-  iEvent.getByToken(jetToken_, jets);
   if (!iEvent.getByToken(jetToken_, jets)) return;
 
   edm::Handle<edm::View<cat::MET> > mets;

--- a/CatAnalyzer/plugins/TTbarDileptonEventSelector.cc
+++ b/CatAnalyzer/plugins/TTbarDileptonEventSelector.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -13,7 +12,6 @@
 //#include "DataFormats/Candidate/interface/CompositeCandidate.h"
 //#include "DataFormats/Candidate/interface/CompositeRefCandidate.h"
 #include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
-#include "CommonTools/Utils/interface/PtComparator.h"
 
 using namespace std;
 

--- a/CatAnalyzer/plugins/TTbarDileptonEventSelector.cc
+++ b/CatAnalyzer/plugins/TTbarDileptonEventSelector.cc
@@ -24,31 +24,27 @@ public:
   void produce(edm::Event & event, const edm::EventSetup&) override;
 
 private:
-  typedef cat::Muon TMuon;
-  typedef cat::Electron TElectron;;
-  typedef cat::Jet TJet;
-  typedef cat::MET TMET;
-  edm::EDGetTokenT<edm::View<TMuon> > muonToken_;
-  edm::EDGetTokenT<edm::View<TElectron> > electronToken_;
-  edm::EDGetTokenT<edm::View<TJet> > jetToken_;
-  edm::EDGetTokenT<edm::View<TMET> > metToken_;
+  edm::EDGetTokenT<cat::MuonCollection> muonToken_;
+  edm::EDGetTokenT<cat::ElectronCollection> electronToken_;
+  edm::EDGetTokenT<cat::JetCollection> jetToken_;
+  edm::EDGetTokenT<cat::METCollection> metToken_;
 
 private:
-  bool isGoodMuon(const TMuon& mu)
+  bool isGoodMuon(const cat::Muon& mu)
   {
     if ( mu.pt() <= 20 or std::abs(mu.eta()) >= 2.4 ) return false;
     if ( mu.relIso(0.4) >= 0.12 ) return false;
     if ( !mu.isTightMuon() ) return false;
     return true;
   }
-  bool isVetoMuon(const TMuon& mu)
+  bool isVetoMuon(const cat::Muon& mu)
   {
     if ( mu.pt() <= 20 or std::abs(mu.eta()) >= 2.4 ) return false;
     if ( mu.relIso(0.4) >= 0.2 ) return false;
     if ( !mu.isLooseMuon() ) return false;
     return true;
   }
-  bool isGoodElectron(const TElectron& el)
+  bool isGoodElectron(const cat::Electron& el)
   {
     if ( el.pt() <= 20 or std::abs(el.eta()) >= 2.4 ) return false;
     //if ( el.relIso(0.3) >= 0.11 ) return false;
@@ -58,7 +54,7 @@ private:
     if ( scEta >= 1.4442 and scEta <= 1.566 ) return false;
     return true;
   }
-  bool isVetoElectron(const TElectron& el)
+  bool isVetoElectron(const cat::Electron& el)
   {
     if ( el.pt()  <= 20 or std::abs(el.eta()) >= 2.4 ) return false;
     if ( !el.electronID(eleVetoIdName_) ) return false;
@@ -69,7 +65,7 @@ private:
     if ( scEta >= 1.566  and relIso03 >= 0.2075 ) return false;
     return true;
   }
-  bool isBjet(const TJet& jet)
+  bool isBjet(const cat::Jet& jet)
   {
     if ( jet.bDiscriminator(bTagName_) >= 0.814 ) return true;
     return false;
@@ -103,10 +99,10 @@ TTbarDileptonEventSelector::TTbarDileptonEventSelector(const edm::ParameterSet& 
   eleVetoIdName_(pset.getParameter<std::string>("eleVetoIdName")),
   bTagName_(pset.getParameter<std::string>("bTagName"))
 {
-  muonToken_ = consumes<edm::View<TMuon> >(pset.getParameter<edm::InputTag>("muons"));
-  electronToken_ = consumes<edm::View<TElectron> >(pset.getParameter<edm::InputTag>("electrons"));
-  jetToken_ = consumes<edm::View<TJet> >(pset.getParameter<edm::InputTag>("jets"));
-  metToken_ = consumes<edm::View<TMET> >(pset.getParameter<edm::InputTag>("mets"));
+  muonToken_ = consumes<cat::MuonCollection>(pset.getParameter<edm::InputTag>("muons"));
+  electronToken_ = consumes<cat::ElectronCollection>(pset.getParameter<edm::InputTag>("electrons"));
+  jetToken_ = consumes<cat::JetCollection>(pset.getParameter<edm::InputTag>("jets"));
+  metToken_ = consumes<cat::METCollection>(pset.getParameter<edm::InputTag>("mets"));
 
   produces<int>("channel");
   produces<int>("nLeptons");
@@ -127,17 +123,17 @@ void TTbarDileptonEventSelector::produce(edm::Event& event, const edm::EventSetu
   std::auto_ptr<std::vector<reco::CandidatePtr> > out_jets(new std::vector<reco::CandidatePtr>);
 
   // MET first
-  edm::Handle<edm::View<TMET> > metHandle;
+  edm::Handle<cat::METCollection> metHandle;
   event.getByToken(metToken_, metHandle);
   const auto& metP4 = metHandle->at(0).p4();
 
   do
   {
     // Do the leptons
-    edm::Handle<edm::View<TMuon> > muonHandle;
+    edm::Handle<cat::MuonCollection> muonHandle;
     event.getByToken(muonToken_, muonHandle);
 
-    edm::Handle<edm::View<TElectron> > electronHandle;
+    edm::Handle<cat::ElectronCollection> electronHandle;
     event.getByToken(electronToken_, electronHandle);
 
     std::vector<reco::CandidatePtr> leptons;
@@ -200,7 +196,7 @@ void TTbarDileptonEventSelector::produce(edm::Event& event, const edm::EventSetu
     }
 
     // Continue to jets
-    edm::Handle<edm::View<TJet> > jetHandle;
+    edm::Handle<cat::JetCollection> jetHandle;
     event.getByToken(jetToken_, jetHandle);
     for ( int i=0, n=jetHandle->size(); i<n; ++i )
     {
@@ -226,8 +222,8 @@ void TTbarDileptonEventSelector::produce(edm::Event& event, const edm::EventSetu
       const string bTagName(bTagName_);
       std::nth_element(out_jets->begin(), out_jets->begin()+nBjets, out_jets->end(),
                        [bTagName](reco::CandidatePtr a, reco::CandidatePtr b){
-                         const double bTag1 = dynamic_cast<const TJet&>(*a).bDiscriminator(bTagName);
-                         const double bTag2 = dynamic_cast<const TJet&>(*b).bDiscriminator(bTagName);
+                         const double bTag1 = dynamic_cast<const cat::Jet&>(*a).bDiscriminator(bTagName);
+                         const double bTag2 = dynamic_cast<const cat::Jet&>(*b).bDiscriminator(bTagName);
                          return bTag1 > bTag2;});
       // Sort by pt for the others
       std::sort(out_jets->begin()+nBjets, out_jets->end(), GtByPtPtr);

--- a/CatAnalyzer/plugins/TTbarDileptonKinSolutionProducer.cc
+++ b/CatAnalyzer/plugins/TTbarDileptonKinSolutionProducer.cc
@@ -1,4 +1,3 @@
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -14,7 +13,6 @@
 //#include "DataFormats/Candidate/interface/CompositeCandidate.h"
 //#include "DataFormats/Candidate/interface/CompositeRefCandidate.h"
 #include "DataFormats/Candidate/interface/CompositePtrCandidate.h"
-#include "CommonTools/Utils/interface/PtComparator.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 using namespace std;

--- a/CatAnalyzer/plugins/TTbarDileptonKinSolutionProducer.cc
+++ b/CatAnalyzer/plugins/TTbarDileptonKinSolutionProducer.cc
@@ -28,10 +28,6 @@ public:
   void produce(edm::Event & event, const edm::EventSetup&) override;
 
 private:
-  typedef cat::Muon TMuon;
-  typedef cat::Electron TElectron;;
-  typedef cat::Jet TJet;
-  typedef cat::MET TMET;
   edm::EDGetTokenT<edm::View<reco::CandidatePtr> > leptonPtrToken_;
   edm::EDGetTokenT<edm::View<reco::CandidatePtr> > jetPtrToken_;
   edm::EDGetTokenT<edm::View<reco::Candidate> > leptonToken_;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -23,7 +23,7 @@
 using namespace std;
 using namespace cat;
 
-class TtbarDiLeptonAnalyzer : public edm::EDAnalyzer {
+class TtbarDiLeptonAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit TtbarDiLeptonAnalyzer(const edm::ParameterSet&);
   ~TtbarDiLeptonAnalyzer();
@@ -118,6 +118,7 @@ TtbarDiLeptonAnalyzer::TtbarDiLeptonAnalyzer(const edm::ParameterSet& iConfig)
 
   solver.reset(new TtFullLepKinSolver(tmassbegin, tmassend, tmassstep, nupars));
 
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
   ttree_ = fs->make<TTree>("tree", "tree");
   ttree_->Branch("parton_channel", &b_partonChannel, "parton_channel/I");

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -250,11 +250,11 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
 
     if ( !(partonTop_genParticles->empty()) ){
 
-      // Get Top quark pairs 
+      // Get Top quark pairs
       const auto parton1 = &partonTop_genParticles->at(0);
       const auto parton2 = &partonTop_genParticles->at(1);
       // Get W and b quarks
-      if ( parton1 and parton2 ) { 
+      if ( parton1 and parton2 ) {
         const auto partonW1 = parton1->daughter(0);
         const auto partonB1 = parton1->daughter(1);
         const auto partonW2 = parton2->daughter(0);
@@ -266,10 +266,10 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
           const auto partonW21 = partonW2->daughter(0);
 
           // Fill lepton informations
-		  b_partonlep1_pt = partonW11->pt();
-		  b_partonlep1_eta = partonW11->eta();
-		  b_partonlep2_pt = partonW21->pt();
-		  b_partonlep2_eta = partonW21->eta();
+          b_partonlep1_pt = partonW11->pt();
+          b_partonlep1_eta = partonW11->eta();
+          b_partonlep2_pt = partonW21->pt();
+          b_partonlep2_eta = partonW21->eta();
         }
       }
     }
@@ -279,12 +279,12 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     if ( !(pseudoTopHandle->empty()) ){
       b_pseudoTopChannel = CH_NONE;
 
-      // Get Top quark pairs 
+      // Get Top quark pairs
       const auto pseudoTop1 = &pseudoTopHandle->at(0);
       const auto pseudoTop2 = &pseudoTopHandle->at(1);
 
       // Get W and b quarks
-      if ( pseudoTop1 and pseudoTop2 ) { 
+      if ( pseudoTop1 and pseudoTop2 ) {
         const auto pseudoW1 = pseudoTop1->daughter(0);
         const auto pseudoB1 = pseudoTop1->daughter(1);
         const auto pseudoW2 = pseudoTop2->daughter(0);
@@ -298,11 +298,11 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
           // Fill leps informations
           const int pseudoW1DauId = abs(pseudoW11->pdgId());
           const int pseudoW2DauId = abs(pseudoW21->pdgId());
-		  b_pseudoToplep1_pt = pseudoW11->pt();
-		  b_pseudoToplep1_eta = pseudoW11->eta();
-		  b_pseudoToplep2_pt = pseudoW21->pt();
-		  b_pseudoToplep2_eta = pseudoW21->eta();
-          if ( pseudoW1DauId > 10 and pseudoW2DauId > 10 ) { 
+          b_pseudoToplep1_pt = pseudoW11->pt();
+          b_pseudoToplep1_eta = pseudoW11->eta();
+          b_pseudoToplep2_pt = pseudoW21->pt();
+          b_pseudoToplep2_eta = pseudoW21->eta();
+          if ( pseudoW1DauId > 10 and pseudoW2DauId > 10 ) {
             switch ( pseudoW1DauId+pseudoW2DauId ) {
               case 22: b_pseudoTopChannel = CH_ELEL; break;
               case 26: b_pseudoTopChannel = CH_MUMU; break;
@@ -325,7 +325,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
   selectElecs(*electrons, recolep);
   if (recolep.size() < 2){
     ttree_->Fill();
-	return;
+    return;
   }
   sort(recolep.begin(), recolep.end(), GtByCandPt());
   const cat::Particle& recolep1 = recolep[0];
@@ -457,7 +457,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
   b_ttbar_phi = ttbar.Phi();
   b_ttbar_m = ttbar.M();
   b_ttbar_rapi = ttbar.Rapidity();
-  
+
   b_maxweight = maxweight;
   //  printf("maxweight %f, top1.M() %f, top2.M() %f \n",maxweight, top1.M(), top2.M() );
   // printf("%2d, %2d, %2d, %2d, %6.2f, %6.2f, %6.2f\n", b_njet, b_nbjet, b_step, b_channel, b_MET, b_ll_mass, b_maxweight);
@@ -510,7 +510,7 @@ std::vector<cat::Jet> TtbarDiLeptonAnalyzer::selectJets(const vector<cat::Jet>& 
   std::vector<cat::Jet> seljets;
   for (auto& jet : jets) {
     if (jet.pt() < 30.) continue;
-    if (std::abs(jet.eta()) > 2.4)	continue;
+    if (std::abs(jet.eta()) > 2.4)  continue;
     if (!jet.LooseId()) continue;
 
     bool hasOverLap = false;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -37,8 +37,8 @@ private:
 
   void selectMuons(const cat::MuonCollection& muons, ParticleCollection& selmuons) const;
   void selectElecs(const cat::ElectronCollection& elecs, ParticleCollection& selelecs) const;
-  JetCollection selectJets(const JetCollection& jets, const ParticleCollection& recolep) const;
-  JetCollection selectBJets(const JetCollection& jets) const;
+  cat::JetCollection selectJets(const cat::JetCollection& jets, const ParticleCollection& recolep) const;
+  cat::JetCollection selectBJets(const cat::JetCollection& jets) const;
   const reco::Candidate* getLast(const reco::Candidate* p) const;
 
   edm::EDGetTokenT<int> recoFiltersToken_;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -1,5 +1,3 @@
-// user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -48,12 +48,12 @@ private:
   edm::EDGetTokenT<cat::ElectronCollection> elecToken_;
   edm::EDGetTokenT<cat::JetCollection>      jetToken_;
   edm::EDGetTokenT<cat::METCollection>      metToken_;
-  edm::EDGetTokenT<reco::VertexCollection >   vtxToken_;
+  edm::EDGetTokenT<reco::VertexCollection>   vtxToken_;
   edm::EDGetTokenT<int>          partonTop_channel_;
   edm::EDGetTokenT<vector<int> > partonTop_modes_;
-  edm::EDGetTokenT<reco::GenParticleCollection > partonTop_genParticles_;
+  edm::EDGetTokenT<reco::GenParticleCollection> partonTop_genParticles_;
 
-  edm::EDGetTokenT<reco::GenParticleCollection > pseudoTop_;
+  edm::EDGetTokenT<reco::GenParticleCollection> pseudoTop_;
 
   TTree * ttree_;
   int b_partonChannel, b_partonMode1, b_partonMode2;
@@ -100,15 +100,15 @@ TtbarDiLeptonAnalyzer::TtbarDiLeptonAnalyzer(const edm::ParameterSet& iConfig)
   elecToken_ = consumes<cat::ElectronCollection>(iConfig.getParameter<edm::InputTag>("electrons"));
   jetToken_  = consumes<cat::JetCollection>(iConfig.getParameter<edm::InputTag>("jets"));
   metToken_  = consumes<cat::METCollection>(iConfig.getParameter<edm::InputTag>("mets"));
-  vtxToken_  = consumes<reco::VertexCollection >(iConfig.getParameter<edm::InputTag>("vertices"));
+  vtxToken_  = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"));
 
   isTTbarMC_ = iConfig.getParameter<bool>("isTTbarMC");
   if ( isTTbarMC_ ) {
     partonTop_channel_ = consumes<int>(iConfig.getParameter<edm::InputTag>("partonTop_channel"));
     partonTop_modes_   = consumes<vector<int> >(iConfig.getParameter<edm::InputTag>("partonTop_modes"));
-    partonTop_genParticles_   = consumes<reco::GenParticleCollection >(iConfig.getParameter<edm::InputTag>("partonTop_genParticles"));
+    partonTop_genParticles_   = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("partonTop_genParticles"));
 
-    pseudoTop_   = consumes<reco::GenParticleCollection >(iConfig.getParameter<edm::InputTag>("pseudoTop"));
+    pseudoTop_   = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("pseudoTop"));
   }
 
   const double tmassbegin = iConfig.getParameter<double>       ("tmassbegin");
@@ -231,7 +231,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
   if (isTTbarMC_){
     edm::Handle<int> partonTop_channel;
     edm::Handle<vector<int> > partonTop_modes;
-    edm::Handle<reco::GenParticleCollection > partonTop_genParticles;
+    edm::Handle<reco::GenParticleCollection> partonTop_genParticles;
     iEvent.getByToken(partonTop_channel_, partonTop_channel);
     iEvent.getByToken(partonTop_modes_, partonTop_modes);
     iEvent.getByToken(partonTop_genParticles_, partonTop_genParticles);
@@ -272,7 +272,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
       }
     }
 
-    edm::Handle<reco::GenParticleCollection > pseudoTopHandle;
+    edm::Handle<reco::GenParticleCollection> pseudoTopHandle;
     iEvent.getByToken(pseudoTop_          , pseudoTopHandle);
     if ( !(pseudoTopHandle->empty()) ){
       b_pseudoTopChannel = CH_NONE;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -40,8 +40,8 @@ private:
 
   void selectMuons(const vector<cat::Muon>& muons, Particles& selmuons) const;
   void selectElecs(const vector<cat::Electron>& elecs, Particles& selelecs) const;
-  void selectJets(const Jets& jets, const Particles& recolep, Jets& seljets) const;
-  void selectBJets(const Jets& jets, Jets& selBjets) const;
+  Jets selectJets(const Jets& jets, const Particles& recolep) const;
+  Jets selectBJets(const Jets& jets) const;
   const reco::Candidate* getLast(const reco::Candidate* p) const;
 
   edm::EDGetTokenT<int> recoFiltersToken_;
@@ -369,9 +369,8 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
   }
   cutflow_[++b_step][b_channel]++;
 
-  Jets selectedJets, selectedBJets;
-  selectJets(*jets, recolep, selectedJets);
-  selectBJets(selectedJets, selectedBJets);
+  Jets&& selectedJets = selectJets(*jets, recolep);
+  Jets&& selectedBJets = selectBJets(selectedJets);
   const TLorentzVector met = mets->front().tlv();
   b_MET = met.Pt();
   b_njet = selectedJets.size();
@@ -506,9 +505,9 @@ void TtbarDiLeptonAnalyzer::selectElecs(const std::vector<cat::Electron>& elecs,
   }
 }
 
-void TtbarDiLeptonAnalyzer::selectJets(const vector<cat::Jet>& jets, const Particles& recolep, Jets& seljets) const
+std::vector<cat::Jet> TtbarDiLeptonAnalyzer::selectJets(const vector<cat::Jet>& jets, const Particles& recolep) const
 {
-  seljets.clear();
+  std::vector<cat::Jet> seljets;
   for (auto& jet : jets) {
     if (jet.pt() < 30.) continue;
     if (std::abs(jet.eta()) > 2.4)	continue;
@@ -522,15 +521,18 @@ void TtbarDiLeptonAnalyzer::selectJets(const vector<cat::Jet>& jets, const Parti
     // printf("jet with pt %4.1f\n", jet.pt());
     seljets.push_back(jet);
   }
+  return seljets;
 }
 
-void TtbarDiLeptonAnalyzer::selectBJets(const Jets& jets, Jets& selBjets) const
+std::vector<cat::Jet> TtbarDiLeptonAnalyzer::selectBJets(const Jets& jets) const
 {
+  std::vector<cat::Jet> selBjets;
   for (auto& jet : jets) {
     if (jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags") < 0.814) continue;
     //printf("b jet with pt %4.1f\n", jet.pt());
     selBjets.push_back(jet);
   }
+  return selBjets;
 }
 
 //define this as a plug-in

--- a/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
@@ -397,8 +397,8 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
 
-  std::vector<cat::Electron> selectedElectrons;
-  std::vector<cat::Electron> vetoElectrons;
+  cat::ElectronCollection selectedElectrons;
+  cat::ElectronCollection vetoElectrons;
 
   Handle<edm::View<cat::Electron> > electrons;
   iEvent.getByToken(electronToken_, electrons);
@@ -417,8 +417,8 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
 
-  std::vector<cat::Muon> selectedMuons;
-  std::vector<cat::Muon> vetoMuons;
+  cat::MuonCollection selectedMuons;
+  cat::MuonCollection vetoMuons;
 
   Handle<edm::View<cat::Muon> > muons;
   iEvent.getByToken(muonToken_, muons);

--- a/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
@@ -523,33 +523,33 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
       if(dr_LepJet > 0.4) cleanJet = true;
 
       if(goodJet && cleanJet){
-  // Basic variables
-  b_Jet_px->push_back(jet.px());
-  b_Jet_py->push_back(jet.py());
-  b_Jet_pz->push_back(jet.pz());
-  b_Jet_E ->push_back(jet.energy());
+        // Basic variables
+        b_Jet_px->push_back(jet.px());
+        b_Jet_py->push_back(jet.py());
+        b_Jet_pz->push_back(jet.pz());
+        b_Jet_E ->push_back(jet.energy());
 
-  // Parton Flavour
-  b_Jet_partonFlavour->push_back(jet.partonFlavour());
-  b_Jet_hadronFlavour->push_back(jet.hadronFlavour());
+        // Parton Flavour
+        b_Jet_partonFlavour->push_back(jet.partonFlavour());
+        b_Jet_hadronFlavour->push_back(jet.hadronFlavour());
 
-  // Smeared and Shifted
-  b_Jet_smearedRes     ->push_back(jet.smearedRes() );
-  b_Jet_smearedResDown ->push_back(jet.smearedResDown());
-  b_Jet_smearedResUp   ->push_back(jet.smearedResUp());
-  b_Jet_shiftedEnUp    ->push_back(jet.shiftedEnUp());
-  b_Jet_shiftedEnDown  ->push_back(jet.shiftedEnDown());
+        // Smeared and Shifted
+        b_Jet_smearedRes     ->push_back(jet.smearedRes() );
+        b_Jet_smearedResDown ->push_back(jet.smearedResDown());
+        b_Jet_smearedResUp   ->push_back(jet.smearedResUp());
+        b_Jet_shiftedEnUp    ->push_back(jet.shiftedEnUp());
+        b_Jet_shiftedEnDown  ->push_back(jet.shiftedEnDown());
 
-  // b-tag discriminant
-  float jet_btagDis_CSV = jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
-  b_Jet_CSV ->push_back(jet_btagDis_CSV);
+        // b-tag discriminant
+        float jet_btagDis_CSV = jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+        b_Jet_CSV ->push_back(jet_btagDis_CSV);
 
-  // BTagSFUtil *fBTagSF;   //The BTag SF utility
-  // fBTagSF = new BTagSFUtil("CSVv2", "Medium", 0);
+        // BTagSFUtil *fBTagSF;   //The BTag SF utility
+        // fBTagSF = new BTagSFUtil("CSVv2", "Medium", 0);
 
-  // if (fBTagSF->IsTagged(jet_btagDis_CSV, -999999, jet.pt(), jet.eta()) ){
-  //    std::cout << "Is btag Jet....." << std::endl;
-  // }
+        // if (fBTagSF->IsTagged(jet_btagDis_CSV, -999999, jet.pt(), jet.eta()) ){
+        //    std::cout << "Is btag Jet....." << std::endl;
+        // }
       }
     }
 

--- a/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
@@ -324,7 +324,7 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
           } // if(it != 0)
           else momid = 0;
         } // while(momid == id)
-	
+
         int mommomid = momid;
 
         if(mom != 0){
@@ -342,10 +342,10 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
         } // while(mommomid == momid)
 
         if (abs(momid) == 24 && abs(mommomid) == 6){
-	
+
           if (id == -11 || id == -13) GenLep_m = true;
           if (id ==  11 || id ==  13) GenLep_p = true;
-	
+
           // Taus
           if(abs(id) == 15){
             for(unsigned int h = 0; h <  gp.numberOfDaughters(); h++) {
@@ -357,7 +357,7 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
           } // if(taus)
 
         } // if(t->W)
-	
+
       }// if (mu || e || tau)
     } // for(genParticles)
 
@@ -520,36 +520,36 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
       // Jet Cleaning
       TLorentzVector vjet(jet.px(), jet.py(), jet.pz(), jet.energy());
       double dr_LepJet = vjet.DeltaR(lepton);
-      if(dr_LepJet > 0.4) cleanJet = true; 	
+      if(dr_LepJet > 0.4) cleanJet = true;
 
       if(goodJet && cleanJet){
-	// Basic variables
-	b_Jet_px->push_back(jet.px());
-	b_Jet_py->push_back(jet.py());
-	b_Jet_pz->push_back(jet.pz());
-	b_Jet_E ->push_back(jet.energy());
-	
-	// Parton Flavour
-	b_Jet_partonFlavour->push_back(jet.partonFlavour());
-	b_Jet_hadronFlavour->push_back(jet.hadronFlavour());
-	
-	// Smeared and Shifted
-	b_Jet_smearedRes     ->push_back(jet.smearedRes() );
-	b_Jet_smearedResDown ->push_back(jet.smearedResDown());
-	b_Jet_smearedResUp   ->push_back(jet.smearedResUp());
-	b_Jet_shiftedEnUp    ->push_back(jet.shiftedEnUp());
-	b_Jet_shiftedEnDown  ->push_back(jet.shiftedEnDown());
-	
-	// b-tag discriminant
-	float jet_btagDis_CSV = jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
-	b_Jet_CSV ->push_back(jet_btagDis_CSV);
+  // Basic variables
+  b_Jet_px->push_back(jet.px());
+  b_Jet_py->push_back(jet.py());
+  b_Jet_pz->push_back(jet.pz());
+  b_Jet_E ->push_back(jet.energy());
 
-	// BTagSFUtil *fBTagSF;   //The BTag SF utility
-	// fBTagSF = new BTagSFUtil("CSVv2", "Medium", 0);
+  // Parton Flavour
+  b_Jet_partonFlavour->push_back(jet.partonFlavour());
+  b_Jet_hadronFlavour->push_back(jet.hadronFlavour());
 
-	// if (fBTagSF->IsTagged(jet_btagDis_CSV, -999999, jet.pt(), jet.eta()) ){
-	//    std::cout << "Is btag Jet....." << std::endl;
-	// }
+  // Smeared and Shifted
+  b_Jet_smearedRes     ->push_back(jet.smearedRes() );
+  b_Jet_smearedResDown ->push_back(jet.smearedResDown());
+  b_Jet_smearedResUp   ->push_back(jet.smearedResUp());
+  b_Jet_shiftedEnUp    ->push_back(jet.shiftedEnUp());
+  b_Jet_shiftedEnDown  ->push_back(jet.shiftedEnDown());
+
+  // b-tag discriminant
+  float jet_btagDis_CSV = jet.bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+  b_Jet_CSV ->push_back(jet_btagDis_CSV);
+
+  // BTagSFUtil *fBTagSF;   //The BTag SF utility
+  // fBTagSF = new BTagSFUtil("CSVv2", "Medium", 0);
+
+  // if (fBTagSF->IsTagged(jet_btagDis_CSV, -999999, jet.pt(), jet.eta()) ){
+  //    std::cout << "Is btag Jet....." << std::endl;
+  // }
       }
     }
 
@@ -620,7 +620,7 @@ bool TtbarSingleLeptonAnalyzer::IsTightElectron(const cat::Electron & i_electron
   GoodElectron &= (i_electron_candidate.pt() > 20);          // pT
   GoodElectron &= (std::abs(i_electron_candidate.eta()) < 2.1);  // eta
   GoodElectron &= (std::abs(i_electron_candidate.scEta()) < 1.4442 || // eta Super-Cluster
-		   std::abs(i_electron_candidate.scEta()) > 1.566);
+       std::abs(i_electron_candidate.scEta()) > 1.566);
 
   // From https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
   GoodElectron &= i_electron_candidate.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-loose") > 0.0;
@@ -650,7 +650,7 @@ bool TtbarSingleLeptonAnalyzer::IsLooseElectron(const cat::Electron & i_electron
   GoodElectron &= (i_electron_candidate.pt() > 15);          // pT
   GoodElectron &= (std::abs(i_electron_candidate.eta()) < 2.4);  // eta
   GoodElectron &= (std::abs(i_electron_candidate.scEta()) < 1.4442 || // eta Super-Cluster
-		   std::abs(i_electron_candidate.scEta()) > 1.566);
+       std::abs(i_electron_candidate.scEta()) > 1.566);
 
   // From https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
   GoodElectron &= i_electron_candidate.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-medium") > 0.0;

--- a/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
@@ -65,11 +65,11 @@ private:
   // TTbarMC_ == 2, ttbar Background
   int TTbarMC_;
 
-  edm::EDGetTokenT<edm::View<reco::GenParticle> >  genToken_;
-  edm::EDGetTokenT<edm::View<cat::Muon> >          muonToken_;
-  edm::EDGetTokenT<edm::View<cat::Electron> >      electronToken_;
-  edm::EDGetTokenT<edm::View<cat::Jet> >           jetToken_;
-  edm::EDGetTokenT<edm::View<cat::MET> >           metToken_;
+  edm::EDGetTokenT<reco::GenParticleCollection>  genToken_;
+  edm::EDGetTokenT<cat::MuonCollection>          muonToken_;
+  edm::EDGetTokenT<cat::ElectronCollection>      electronToken_;
+  edm::EDGetTokenT<cat::JetCollection>           jetToken_;
+  edm::EDGetTokenT<cat::METCollection>           metToken_;
   edm::EDGetTokenT<int>                            pvToken_;
   edm::EDGetTokenT<float>                          puWeight_;
 
@@ -139,11 +139,11 @@ TtbarSingleLeptonAnalyzer::TtbarSingleLeptonAnalyzer(const edm::ParameterSet& iC
   TTbarMC_ (iConfig.getUntrackedParameter<int>("TTbarSampleLabel", 0))
 {
   //now do what ever initialization is needed
-  genToken_      = consumes<edm::View<reco::GenParticle> >  (iConfig.getParameter<edm::InputTag>("genLabel"));
-  muonToken_     = consumes<edm::View<cat::Muon> >          (iConfig.getParameter<edm::InputTag>("muonLabel"));
-  electronToken_ = consumes<edm::View<cat::Electron> >      (iConfig.getParameter<edm::InputTag>("electronLabel"));
-  jetToken_      = consumes<edm::View<cat::Jet> >           (iConfig.getParameter<edm::InputTag>("jetLabel"));
-  metToken_      = consumes<edm::View<cat::MET> >           (iConfig.getParameter<edm::InputTag>("metLabel"));
+  genToken_      = consumes<reco::GenParticleCollection>  (iConfig.getParameter<edm::InputTag>("genLabel"));
+  muonToken_     = consumes<cat::MuonCollection>          (iConfig.getParameter<edm::InputTag>("muonLabel"));
+  electronToken_ = consumes<cat::ElectronCollection>      (iConfig.getParameter<edm::InputTag>("electronLabel"));
+  jetToken_      = consumes<cat::JetCollection>           (iConfig.getParameter<edm::InputTag>("jetLabel"));
+  metToken_      = consumes<cat::METCollection>           (iConfig.getParameter<edm::InputTag>("metLabel"));
   pvToken_       = consumes<int>                            (iConfig.getParameter<edm::InputTag>("pvLabel"));
   puWeight_      = consumes<float>                          (iConfig.getParameter<edm::InputTag>("puWeight"));
   triggerBits_ = consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerBits"));
@@ -289,7 +289,7 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
 
   if(TTbarMC_ > 0) {
 
-    edm::Handle<edm::View<reco::GenParticle> > genParticles;
+    edm::Handle<reco::GenParticleCollection> genParticles;
     iEvent.getByToken(genToken_, genParticles);
 
     // Gen Status: http://home.thep.lu.se/~torbjorn/pythia81html/ParticleProperties.html
@@ -384,7 +384,7 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
 
-  Handle<edm::View<cat::MET> > MET;
+  Handle<cat::METCollection> MET;
   iEvent.getByToken(metToken_, MET);
 
   // MET-PF
@@ -400,7 +400,7 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
   cat::ElectronCollection selectedElectrons;
   cat::ElectronCollection vetoElectrons;
 
-  Handle<edm::View<cat::Electron> > electrons;
+  Handle<cat::ElectronCollection> electrons;
   iEvent.getByToken(electronToken_, electrons);
 
   for (unsigned int i = 0; i < electrons->size() ; i++) {
@@ -420,7 +420,7 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
   cat::MuonCollection selectedMuons;
   cat::MuonCollection vetoMuons;
 
-  Handle<edm::View<cat::Muon> > muons;
+  Handle<cat::MuonCollection> muons;
   iEvent.getByToken(muonToken_, muons);
 
   for (unsigned int i = 0; i < muons->size() ; i++) {
@@ -506,7 +506,7 @@ void TtbarSingleLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Eve
     //---------------------------------------------------------------------------
     //---------------------------------------------------------------------------
 
-    Handle<edm::View<cat::Jet> > jets;
+    Handle<cat::JetCollection> jets;
     iEvent.getByToken(jetToken_, jets);
 
     for (unsigned int i = 0; i < jets->size() ; i++) {

--- a/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
@@ -17,7 +17,6 @@
 //
 //
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +38,6 @@
 
 #include "TH1.h"
 #include "TTree.h"
-#include "TFile.h"
 #include "TLorentzVector.h"
 //
 // class declaration

--- a/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
@@ -621,7 +621,7 @@ bool TtbarSingleLeptonAnalyzer::IsTightElectron(const cat::Electron & i_electron
   GoodElectron &= (i_electron_candidate.pt() > 20);          // pT
   GoodElectron &= (std::abs(i_electron_candidate.eta()) < 2.1);  // eta
   GoodElectron &= (std::abs(i_electron_candidate.scEta()) < 1.4442 || // eta Super-Cluster
-       std::abs(i_electron_candidate.scEta()) > 1.566);
+                   std::abs(i_electron_candidate.scEta()) > 1.566);
 
   // From https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
   GoodElectron &= i_electron_candidate.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-loose") > 0.0;
@@ -651,7 +651,7 @@ bool TtbarSingleLeptonAnalyzer::IsLooseElectron(const cat::Electron & i_electron
   GoodElectron &= (i_electron_candidate.pt() > 15);          // pT
   GoodElectron &= (std::abs(i_electron_candidate.eta()) < 2.4);  // eta
   GoodElectron &= (std::abs(i_electron_candidate.scEta()) < 1.4442 || // eta Super-Cluster
-       std::abs(i_electron_candidate.scEta()) > 1.566);
+                   std::abs(i_electron_candidate.scEta()) > 1.566);
 
   // From https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2
   GoodElectron &= i_electron_candidate.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-medium") > 0.0;

--- a/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarSingleLeptonAnalyzer.cc
@@ -17,7 +17,7 @@
 //
 //
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -45,7 +45,7 @@
 
 using namespace cat;
 
-class TtbarSingleLeptonAnalyzer : public edm::EDAnalyzer {
+class TtbarSingleLeptonAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit TtbarSingleLeptonAnalyzer(const edm::ParameterSet&);
   ~TtbarSingleLeptonAnalyzer();
@@ -165,6 +165,7 @@ TtbarSingleLeptonAnalyzer::TtbarSingleLeptonAnalyzer(const edm::ParameterSet& iC
 
   b_Jet_CSV  = new std::vector<float>;
 
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
   tree = fs->make<TTree>("tree", "TopTree");
 

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -37,9 +37,9 @@ private:
   vector<cat::Muon> selectMuons(const edm::View<cat::Muon>* muons ) const;
   vector<cat::Electron> selectElecs(const edm::View<cat::Electron>* elecs ) const;
   vector<cat::Jet> selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recolep) const;
-  vector<cat::Jet> selectBJets(const JetCollection& jets) const;
-  int preSelect(const JetCollection& seljets, float MET) const;
-  int JetCategory(const JetCollection& seljets, float MET, float ll_pt) const;
+  vector<cat::Jet> selectBJets(const cat::JetCollection& jets) const;
+  int preSelect(const cat::JetCollection& seljets, float MET) const;
+  int JetCategory(const cat::JetCollection& seljets, float MET, float ll_pt) const;
   int JetCat_GC(float mu1_eta, float mu2_eta) const;
 
   edm::EDGetTokenT<edm::View<cat::Muon> >     muonToken_;
@@ -325,7 +325,7 @@ vector<cat::Jet> h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vecto
   return seljets;
 }
 
-int h2muAnalyzer::preSelect(const JetCollection& seljets, float MET) const
+int h2muAnalyzer::preSelect(const cat::JetCollection& seljets, float MET) const
 {
   int njet = seljets.size();
   if (njet>1){
@@ -342,7 +342,7 @@ int h2muAnalyzer::preSelect(const JetCollection& seljets, float MET) const
   return 0;
 }
 
-int h2muAnalyzer::JetCategory(const JetCollection& seljets, float MET, float diMu_pt) const
+int h2muAnalyzer::JetCategory(const cat::JetCollection& seljets, float MET, float diMu_pt) const
 {
   int presel = preSelect(seljets, MET);
   if (presel==1){

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -175,7 +175,7 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
   vector<cat::Muon>&& selectedMuons = selectMuons( muons.product() );
   sort(selectedMuons.begin(), selectedMuons.end(), GtByCandPt());
-  
+
   if (runOnMC_){
     iEvent.getByToken(mcLabel_,genParticles);
     bool bosonSample = false;
@@ -187,15 +187,15 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       }
       bool isfromBoson = false;
       for (unsigned int i = 0; i < g.numberOfMothers(); ++i){
-	//In case of pdgId() = 23, indicate Z-boson. if it's 25, that becomes higgs.
-	if (g.mother(i)->pdgId() == 23 || g.mother(i)->pdgId() == 25){
-	  isfromBoson = true;
-	  bosonSample = true;
-	}
+  //In case of pdgId() = 23, indicate Z-boson. if it's 25, that becomes higgs.
+  if (g.mother(i)->pdgId() == 23 || g.mother(i)->pdgId() == 25){
+    isfromBoson = true;
+    bosonSample = true;
+  }
       }
       if (isfromBoson){
-	if (g.charge() > 0) genMu1.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
-	else genMu2.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
+  if (g.charge() > 0) genMu1.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
+  else genMu2.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
       }
     }
     if (bosonSample){
@@ -205,14 +205,14 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       b_gen_diMu_pt = gen_diMu.Pt(); b_gen_diMu_eta = gen_diMu.Eta(); b_gen_diMu_phi = gen_diMu.Phi(); b_gen_diMu_m = gen_diMu.M();
 
       for (auto m : selectedMuons){
-	if (genMu1.DeltaR(m.tlv()) < 0.1){
-	  b_gen_mu1_ptRes = (m.pt()-genMu1.Pt())/genMu1.Pt();
-	  b_gen_mu1_isLoose = m.isLooseMuon(); b_gen_mu1_isMedium = m.isMediumMuon(); b_gen_mu1_isTight = m.isTightMuon();
-	}
-	if (genMu2.DeltaR(m.tlv()) < 0.1){
-	  b_gen_mu2_ptRes = (m.pt()-genMu2.Pt())/genMu2.Pt();
-	  b_gen_mu2_isLoose = m.isLooseMuon(); b_gen_mu2_isMedium = m.isMediumMuon(); b_gen_mu2_isTight = m.isTightMuon();
-	}
+  if (genMu1.DeltaR(m.tlv()) < 0.1){
+    b_gen_mu1_ptRes = (m.pt()-genMu1.Pt())/genMu1.Pt();
+    b_gen_mu1_isLoose = m.isLooseMuon(); b_gen_mu1_isMedium = m.isMediumMuon(); b_gen_mu1_isTight = m.isTightMuon();
+  }
+  if (genMu2.DeltaR(m.tlv()) < 0.1){
+    b_gen_mu2_ptRes = (m.pt()-genMu2.Pt())/genMu2.Pt();
+    b_gen_mu2_isLoose = m.isLooseMuon(); b_gen_mu2_isMedium = m.isMediumMuon(); b_gen_mu2_isTight = m.isTightMuon();
+  }
       }
     }
   }
@@ -316,7 +316,7 @@ vector<cat::Jet> h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vecto
   for (auto jet : *jets) {
     if (!jet.LooseId()) continue;
     if (jet.pt() <= 30.) continue;
-    if (std::abs(jet.eta()) >= 2.4)	continue;
+    if (std::abs(jet.eta()) >= 2.4)  continue;
     //if (jet.tlv().DeltaR(recomu[0]) <= 0.4) continue;
     //if (jet.tlv().DeltaR(recomu[1]) <= 0.4) continue;
     // printf("jet with pt %4.1f\n", jet.pt());

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +26,7 @@
 using namespace std;
 using namespace cat;
 
-class h2muAnalyzer : public edm::EDAnalyzer {
+class h2muAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit h2muAnalyzer(const edm::ParameterSet&);
   ~h2muAnalyzer() {};
@@ -82,6 +82,7 @@ h2muAnalyzer::h2muAnalyzer(const edm::ParameterSet& iConfig)
   triggerBits_ = consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerBits"));
   triggerObjects_ = consumes<pat::TriggerObjectStandAloneCollection>(iConfig.getParameter<edm::InputTag>("triggerObjects"));
 
+  usesResource("TFileService");
   edm::Service<TFileService> fs;
   ttree_ = fs->make<TTree>("tree", "tree");
   ttree_->Branch("njet", &b_njet, "njet/I");

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -34,10 +34,10 @@ public:
 private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  vector<cat::Muon> selectMuons(const edm::View<cat::Muon>* muons ) const;
-  vector<cat::Electron> selectElecs(const edm::View<cat::Electron>* elecs ) const;
-  vector<cat::Jet> selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recolep) const;
-  vector<cat::Jet> selectBJets(const cat::JetCollection& jets) const;
+  cat::MuonCollection selectMuons(const edm::View<cat::Muon>* muons ) const;
+  cat::ElectronCollection selectElecs(const edm::View<cat::Electron>* elecs ) const;
+  cat::JetCollection selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recolep) const;
+  cat::JetCollection selectBJets(const cat::JetCollection& jets) const;
   int preSelect(const cat::JetCollection& seljets, float MET) const;
   int JetCategory(const cat::JetCollection& seljets, float MET, float ll_pt) const;
   int JetCat_GC(float mu1_eta, float mu2_eta) const;
@@ -174,7 +174,7 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
   edm::Handle<reco::GenParticleCollection> genParticles;
 
-  vector<cat::Muon>&& selectedMuons = selectMuons( muons.product() );
+  cat::MuonCollection&& selectedMuons = selectMuons( muons.product() );
   sort(selectedMuons.begin(), selectedMuons.end(), GtByCandPt());
 
   if (runOnMC_){
@@ -238,7 +238,7 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   b_MET = met.Pt();
 
   vector<TLorentzVector> recomu;
-  vector<cat::Jet>&& selectedJets = selectJets( jets.product(), recomu );
+  cat::JetCollection&& selectedJets = selectJets( jets.product(), recomu );
 
   b_njet = selectedJets.size();
 
@@ -277,9 +277,9 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   ttree_->Fill();
 }
 
-vector<cat::Muon> h2muAnalyzer::selectMuons(const edm::View<cat::Muon>* muons ) const
+cat::MuonCollection h2muAnalyzer::selectMuons(const edm::View<cat::Muon>* muons ) const
 {
-  vector<cat::Muon> selmuons;
+  cat::MuonCollection selmuons;
   for (auto mu : *muons) {
     if (!mu.isLooseMuon()) continue;
     if (mu.pt() <= 20.) continue;
@@ -292,9 +292,9 @@ vector<cat::Muon> h2muAnalyzer::selectMuons(const edm::View<cat::Muon>* muons ) 
   return selmuons;
 }
 
-vector<cat::Electron> h2muAnalyzer::selectElecs(const edm::View<cat::Electron>* elecs ) const
+cat::ElectronCollection h2muAnalyzer::selectElecs(const edm::View<cat::Electron>* elecs ) const
 {
-  vector<cat::Electron> selelecs;
+  cat::ElectronCollection selelecs;
   for (auto el : *elecs) {
     if (!el.electronID("cutBasedElectronID-PHYS14-PU20bx25-V2-standalone-medium")) continue;
     if (!el.passConversionVeto()) continue;
@@ -311,9 +311,9 @@ vector<cat::Electron> h2muAnalyzer::selectElecs(const edm::View<cat::Electron>* 
   return selelecs;
 }
 
-vector<cat::Jet> h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recomu ) const
+cat::JetCollection h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recomu ) const
 {
-  vector<cat::Jet> seljets;
+  cat::JetCollection seljets;
   for (auto jet : *jets) {
     if (!jet.LooseId()) continue;
     if (jet.pt() <= 30.) continue;

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -1,6 +1,3 @@
-#include <memory>
-// user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -21,7 +18,6 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 #include "TTree.h"
-#include "TFile.h"
 #include "TLorentzVector.h"
 
 #define _USE_MATH_DEFINES

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -188,15 +188,15 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       }
       bool isfromBoson = false;
       for (unsigned int i = 0; i < g.numberOfMothers(); ++i){
-  //In case of pdgId() = 23, indicate Z-boson. if it's 25, that becomes higgs.
-  if (g.mother(i)->pdgId() == 23 || g.mother(i)->pdgId() == 25){
-    isfromBoson = true;
-    bosonSample = true;
-  }
+        //In case of pdgId() = 23, indicate Z-boson. if it's 25, that becomes higgs.
+        if (g.mother(i)->pdgId() == 23 || g.mother(i)->pdgId() == 25){
+          isfromBoson = true;
+          bosonSample = true;
+        }
       }
       if (isfromBoson){
-  if (g.charge() > 0) genMu1.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
-  else genMu2.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
+        if (g.charge() > 0) genMu1.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
+        else genMu2.SetPtEtaPhiM(g.pt(), g.eta(), g.phi(), g.mass());
       }
     }
     if (bosonSample){
@@ -206,14 +206,14 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       b_gen_diMu_pt = gen_diMu.Pt(); b_gen_diMu_eta = gen_diMu.Eta(); b_gen_diMu_phi = gen_diMu.Phi(); b_gen_diMu_m = gen_diMu.M();
 
       for (auto m : selectedMuons){
-  if (genMu1.DeltaR(m.tlv()) < 0.1){
-    b_gen_mu1_ptRes = (m.pt()-genMu1.Pt())/genMu1.Pt();
-    b_gen_mu1_isLoose = m.isLooseMuon(); b_gen_mu1_isMedium = m.isMediumMuon(); b_gen_mu1_isTight = m.isTightMuon();
-  }
-  if (genMu2.DeltaR(m.tlv()) < 0.1){
-    b_gen_mu2_ptRes = (m.pt()-genMu2.Pt())/genMu2.Pt();
-    b_gen_mu2_isLoose = m.isLooseMuon(); b_gen_mu2_isMedium = m.isMediumMuon(); b_gen_mu2_isTight = m.isTightMuon();
-  }
+        if (genMu1.DeltaR(m.tlv()) < 0.1){
+          b_gen_mu1_ptRes = (m.pt()-genMu1.Pt())/genMu1.Pt();
+          b_gen_mu1_isLoose = m.isLooseMuon(); b_gen_mu1_isMedium = m.isMediumMuon(); b_gen_mu1_isTight = m.isTightMuon();
+        }
+        if (genMu2.DeltaR(m.tlv()) < 0.1){
+          b_gen_mu2_ptRes = (m.pt()-genMu2.Pt())/genMu2.Pt();
+          b_gen_mu2_isLoose = m.isLooseMuon(); b_gen_mu2_isMedium = m.isMediumMuon(); b_gen_mu2_isTight = m.isTightMuon();
+        }
       }
     }
   }

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -29,18 +29,18 @@ using namespace cat;
 class h2muAnalyzer : public edm::EDAnalyzer {
 public:
   explicit h2muAnalyzer(const edm::ParameterSet&);
-  ~h2muAnalyzer();
+  ~h2muAnalyzer() {};
 
 private:
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  vector<cat::Muon> selectMuons(const edm::View<cat::Muon>* muons );
-  vector<cat::Electron> selectElecs(const edm::View<cat::Electron>* elecs );
-  vector<cat::Jet> selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recolep);
-  vector<cat::Jet> selectBJets(vector<cat::Jet> & jets );
-  int preSelect(vector<cat::Jet> seljets, float MET);
-  int JetCategory(vector<cat::Jet> seljets, float MET, float ll_pt);
-  int JetCat_GC(float mu1_eta, float mu2_eta);
+  vector<cat::Muon> selectMuons(const edm::View<cat::Muon>* muons ) const;
+  vector<cat::Electron> selectElecs(const edm::View<cat::Electron>* elecs ) const;
+  vector<cat::Jet> selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recolep) const;
+  vector<cat::Jet> selectBJets(vector<cat::Jet> & jets) const;
+  int preSelect(vector<cat::Jet> seljets, float MET) const;
+  int JetCategory(vector<cat::Jet> seljets, float MET, float ll_pt) const;
+  int JetCat_GC(float mu1_eta, float mu2_eta) const;
 
   edm::EDGetTokenT<edm::View<cat::Muon> >     muonToken_;
   edm::EDGetTokenT<edm::View<cat::Electron> > elecToken_;
@@ -70,6 +70,7 @@ private:
 
   bool runOnMC_;
 };
+
 h2muAnalyzer::h2muAnalyzer(const edm::ParameterSet& iConfig)
 {
   muonToken_ = consumes<edm::View<cat::Muon> >(iConfig.getParameter<edm::InputTag>("muons"));
@@ -133,7 +134,6 @@ h2muAnalyzer::h2muAnalyzer(const edm::ParameterSet& iConfig)
   ttree_->Branch("gen_diMu_m", &b_gen_diMu_m, "gen_diMu_m/F");
 
 }
-h2muAnalyzer::~h2muAnalyzer(){}
 
 void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
@@ -276,7 +276,7 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   ttree_->Fill();
 }
 
-vector<cat::Muon> h2muAnalyzer::selectMuons(const edm::View<cat::Muon>* muons )
+vector<cat::Muon> h2muAnalyzer::selectMuons(const edm::View<cat::Muon>* muons ) const
 {
   vector<cat::Muon> selmuons;
   for (auto mu : *muons) {
@@ -291,7 +291,7 @@ vector<cat::Muon> h2muAnalyzer::selectMuons(const edm::View<cat::Muon>* muons )
   return selmuons;
 }
 
-vector<cat::Electron> h2muAnalyzer::selectElecs(const edm::View<cat::Electron>* elecs )
+vector<cat::Electron> h2muAnalyzer::selectElecs(const edm::View<cat::Electron>* elecs ) const
 {
   vector<cat::Electron> selelecs;
   for (auto el : *elecs) {
@@ -310,7 +310,7 @@ vector<cat::Electron> h2muAnalyzer::selectElecs(const edm::View<cat::Electron>* 
   return selelecs;
 }
 
-vector<cat::Jet> h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recomu )
+vector<cat::Jet> h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recomu ) const
 {
   vector<cat::Jet> seljets;
   for (auto jet : *jets) {
@@ -325,7 +325,7 @@ vector<cat::Jet> h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vecto
   return seljets;
 }
 
-int h2muAnalyzer::preSelect(vector<cat::Jet> seljets, float MET)
+int h2muAnalyzer::preSelect(vector<cat::Jet> seljets, float MET) const
 {
   int njet = seljets.size();
   if (njet>1){
@@ -342,7 +342,7 @@ int h2muAnalyzer::preSelect(vector<cat::Jet> seljets, float MET)
   return 0;
 }
 
-int h2muAnalyzer::JetCategory(vector<cat::Jet> seljets, float MET, float diMu_pt)
+int h2muAnalyzer::JetCategory(vector<cat::Jet> seljets, float MET, float diMu_pt) const
 {
   int presel = preSelect(seljets, MET);
   if (presel==1){
@@ -368,7 +368,7 @@ int h2muAnalyzer::JetCategory(vector<cat::Jet> seljets, float MET, float diMu_pt
   return 0;
 }
 
-int h2muAnalyzer::JetCat_GC(float mu1_eta, float mu2_eta)
+int h2muAnalyzer::JetCat_GC(float mu1_eta, float mu2_eta) const
 {
   const float eta_mu[2] = {std::abs(mu1_eta),std::abs(mu2_eta)};
   int GC=0;

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -30,7 +30,6 @@ class h2muAnalyzer : public edm::EDAnalyzer {
 public:
   explicit h2muAnalyzer(const edm::ParameterSet&);
   ~h2muAnalyzer();
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
@@ -174,7 +173,7 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
   edm::Handle<reco::GenParticleCollection> genParticles;
 
-  vector<cat::Muon> selectedMuons = selectMuons( muons.product() );
+  vector<cat::Muon>&& selectedMuons = selectMuons( muons.product() );
   sort(selectedMuons.begin(), selectedMuons.end(), GtByCandPt());
   
   if (runOnMC_){
@@ -238,7 +237,7 @@ void h2muAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   b_MET = met.Pt();
 
   vector<TLorentzVector> recomu;
-  vector<cat::Jet> selectedJets = selectJets( jets.product(), recomu );
+  vector<cat::Jet>&& selectedJets = selectJets( jets.product(), recomu );
 
   b_njet = selectedJets.size();
 
@@ -371,22 +370,14 @@ int h2muAnalyzer::JetCategory(vector<cat::Jet> seljets, float MET, float diMu_pt
 
 int h2muAnalyzer::JetCat_GC(float mu1_eta, float mu2_eta)
 {
-  float eta_mu[2] = {abs(mu1_eta),abs(mu2_eta)};
-  float GC=0;
+  const float eta_mu[2] = {std::abs(mu1_eta),std::abs(mu2_eta)};
+  int GC=0;
   for(int i=0; i<2; i++){
-    if (eta_mu[i] < 0.8) GC += 1;
-    if (eta_mu[i] > 0.8 && eta_mu[i] < 1.5) GC += 10;
-    if (eta_mu[i] > 1.5 && eta_mu[i] < 2.4) GC += 100;
+    if      (eta_mu[i] < 0.8) GC += 1;
+    else if (eta_mu[i] < 1.5) GC += 10;
+    else if (eta_mu[i] < 2.4) GC += 100;
   }
   return GC;
-}
-
-void h2muAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
-  edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -37,9 +37,9 @@ private:
   vector<cat::Muon> selectMuons(const edm::View<cat::Muon>* muons ) const;
   vector<cat::Electron> selectElecs(const edm::View<cat::Electron>* elecs ) const;
   vector<cat::Jet> selectJets(const edm::View<cat::Jet>* jets, vector<TLorentzVector> recolep) const;
-  vector<cat::Jet> selectBJets(vector<cat::Jet> & jets) const;
-  int preSelect(vector<cat::Jet> seljets, float MET) const;
-  int JetCategory(vector<cat::Jet> seljets, float MET, float ll_pt) const;
+  vector<cat::Jet> selectBJets(const JetCollection& jets) const;
+  int preSelect(const JetCollection& seljets, float MET) const;
+  int JetCategory(const JetCollection& seljets, float MET, float ll_pt) const;
   int JetCat_GC(float mu1_eta, float mu2_eta) const;
 
   edm::EDGetTokenT<edm::View<cat::Muon> >     muonToken_;
@@ -325,7 +325,7 @@ vector<cat::Jet> h2muAnalyzer::selectJets(const edm::View<cat::Jet>* jets, vecto
   return seljets;
 }
 
-int h2muAnalyzer::preSelect(vector<cat::Jet> seljets, float MET) const
+int h2muAnalyzer::preSelect(const JetCollection& seljets, float MET) const
 {
   int njet = seljets.size();
   if (njet>1){
@@ -342,7 +342,7 @@ int h2muAnalyzer::preSelect(vector<cat::Jet> seljets, float MET) const
   return 0;
 }
 
-int h2muAnalyzer::JetCategory(vector<cat::Jet> seljets, float MET, float diMu_pt) const
+int h2muAnalyzer::JetCategory(const JetCollection& seljets, float MET, float diMu_pt) const
 {
   int presel = preSelect(seljets, MET);
   if (presel==1){


### PR DESCRIPTION
Use the r-value reference syntax in C++11 standard - better readability but no cost of un-necessary copy constructors.

Purely technical update. No change in physics.
