### PR TITLE
New relval input file, new PileupInfo label

### DIFF
--- a/CatProducer/plugins/PileupWeightProducer.cc
+++ b/CatProducer/plugins/PileupWeightProducer.cc
@@ -41,9 +41,9 @@ private:
 };
 
 PileupWeightProducer::PileupWeightProducer(const edm::ParameterSet& pset):
-  isStandardWeight_(pset.getParameter<bool>("isStandardWeight"))
+  isStandardWeight_(pset.getParameter<bool>("isStandardWeight")),
+  puToken_(consumes<PUInfos>(pset.getParameter<edm::InputTag>("slimmedAddPileupInfo")))
 {
-  puToken_ = consumes<PUInfos>(edm::InputTag("addPileupInfo"));
   if ( isStandardWeight_ )
   {
     std::vector<double> pileupMC = pset.getParameter<std::vector<double> >("pileupMC");

--- a/CatProducer/plugins/PileupWeightProducer.cc
+++ b/CatProducer/plugins/PileupWeightProducer.cc
@@ -42,7 +42,7 @@ private:
 
 PileupWeightProducer::PileupWeightProducer(const edm::ParameterSet& pset):
   isStandardWeight_(pset.getParameter<bool>("isStandardWeight")),
-  puToken_(consumes<PUInfos>(pset.getParameter<edm::InputTag>("slimmedAddPileupInfo")))
+  puToken_(consumes<PUInfos>(pset.getParameter<edm::InputTag>("pileupInfo")))
 {
   if ( isStandardWeight_ )
   {

--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -64,14 +64,14 @@ process.maxEvents.input = options.maxEvents
 if not options.inputFiles:
     if useMiniAOD:
         if runGenTop:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_6_patch6/RelValTTbar_13/MINIAODSIM/MCRUN2_74_V9-v1/00000/2403409D-1225-E511-B64E-0025905A6132.root']
+            process.source.fileNames = ['/store/relval/CMSSW_7_4_15/RelValTTbar_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/0253820F-4772-E511-ADD3-002618943856.root']
         else:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_6_patch6/RelValZMM_13/MINIAODSIM/74X_mcRun2_asymptotic_realisticBS_v0_2015Jul24PU-v1/00000/487C927D-6732-E511-9FB3-0025905B85AA.root']
+            process.source.fileNames = ['/store/relval/CMSSW_7_4_15/RelValZMM_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/10FF6E32-3C72-E511-87AD-0025905A60B4.root']
     else:
         if useGenTop:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_6_patch6/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V9-v1/00000/54F6E09C-1225-E511-842B-0025905A612E.root']
+            process.source.fileNames = ['/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/006F3660-4B5E-E511-B8FD-0025905B8596.root']
         else:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_6_patch6/RelValZMM_13/GEN-SIM-RECO/74X_mcRun2_asymptotic_realisticBS_v0_2015Jul24PU-v1/00000/3E2885EA-6032-E511-B000-0025905A60B6.root']
+            process.source.fileNames = ['/store/relval/CMSSW_7_4_15/RelValZMM_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/18B13146-3872-E511-A382-00261894394D.root']
 if useMiniAOD and options.runOnRelVal == True:
     ## Hack to run on relval sample, controlled with runOnRelVal option
     process.genMetExtractor.metSource = "slimmedMETs::RECO"

--- a/CatProducer/python/pileupWeight_cff.py
+++ b/CatProducer/python/pileupWeight_cff.py
@@ -6,6 +6,8 @@ pileupWeight = cms.EDProducer("PileupWeightProducer",
     pileupRD = cms.vdouble(),
     pileupUp = cms.vdouble(),
     pileupDn = cms.vdouble(),
+    #pileupInfo = cms.InputTag("addPileupInfo"),
+    pileupInfo = cms.InputTag("slimmedAddPileupInfo"),
     vertex = cms.InputTag("offlineSlimmedPrimaryVertices"),
     simpleWeights = cms.vdouble(),
 )

--- a/CatProducer/test/runtests.sh
+++ b/CatProducer/test/runtests.sh
@@ -4,12 +4,12 @@ function die { echo $1: status $2 ;  exit $2; }
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runOnRelVal=1' \
-  'inputFiles=/store/relval/CMSSW_7_4_6_patch6/RelValZMM_13/MINIAODSIM/74X_mcRun2_asymptotic_realisticBS_v0_2015Jul24PU-v1/00000/487C927D-6732-E511-9FB3-0025905B85AA.root' \
+  'inputFiles=/store/relval/CMSSW_7_4_15/RelValZMM_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/10FF6E32-3C72-E511-87AD-0025905A60B4.root' \
   || die 'Failure to run PAT2CAT from MiniAODSIM' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'runOnRelVal=1' \
-  'inputFiles=/store/relval/CMSSW_7_4_6_patch6/RelValTTbar_13/MINIAODSIM/MCRUN2_74_V9-v1/00000/2403409D-1225-E511-B64E-0025905A6132.root' \
+  'inputFiles=/store/relval/CMSSW_7_4_15/RelValTTbar_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/0253820F-4772-E511-ADD3-002618943856.root' \
   || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
@@ -19,10 +19,10 @@ cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=0' 'runOnRelVal=1' \
-  'inputFiles=/store/relval/CMSSW_7_4_6_patch6/RelValZMM_13/GEN-SIM-RECO/74X_mcRun2_asymptotic_realisticBS_v0_2015Jul24PU-v1/00000/3E2885EA-6032-E511-B000-0025905A60B6.root' \
+  'inputFiles=/store/relval/CMSSW_7_4_15/RelValZMM_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/18B13146-3872-E511-A382-00261894394D.root' \
   || die 'Failure to run PAT2CAT from AODSIM' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=0' 'runGenTop=1' 'runOnRelVal=1' \
-  'inputFiles=/store/relval/CMSSW_7_4_6_patch6/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V9-v1/00000/54F6E09C-1225-E511-842B-0025905A612E.root' \
+  'inputFiles=/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/006F3660-4B5E-E511-B8FD-0025905B8596.root' \
   || die 'Failure to run PAT2CAT from AODSIM + GenTop' $?


### PR DESCRIPTION
Old relval input files are deleted, switching to 7515 relval sample.
In this new release, addPileupInfo is renamed to slimmedAddPileupInfo.
