### PR TITLE
Weights from LHE

### DIFF
--- a/CatProducer/plugins/BuildFile.xml
+++ b/CatProducer/plugins/BuildFile.xml
@@ -17,6 +17,7 @@
   <use   name="CondFormats/JetMETObjects"/>
   <use   name="JetMETCorrections/Objects"/>
   <use   name="root"/>
+  <use   name="rootxml"/>
   <use   name="fastjet" />
   <use   name="lhapdf"/>
 </library>

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -34,6 +34,7 @@ public:
   typedef std::vector<int> vint;
   typedef std::vector<float> vfloat;
   typedef std::vector<std::string> vstring;
+  typedef std::vector<vstring> vvstring;
 
 private:
   const bool enforceUnitGenWeight_;
@@ -64,7 +65,7 @@ GenWeightsProducer::GenWeightsProducer(const edm::ParameterSet& pset):
 
   produces<vstring, edm::InRun>("weightTypes");
   produces<vint, edm::InRun>("weightIdxUB");
-  //produces<vector<vstring>, edm::InRun>("weightParams");
+  produces<vvstring, edm::InRun>("weightParams");
 
   produces<float>("genWeight");
   produces<float>("lheWeight");
@@ -88,7 +89,7 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
 {
   std::auto_ptr<vstring> weightTypes(new vstring);
   std::auto_ptr<vint> weightIdxUB(new vint);
-  //std::auto_ptr<vector<vstring> > weightParams(new vector<vstring>);
+  std::auto_ptr<vvstring> weightParams(new vvstring);
 
   do {
     edm::Handle<LHERunInfoProduct> lheHandle;
@@ -127,11 +128,11 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
 
       weightTypes->push_back(weightTypeObj->GetValue());
       int weightSize = 0;
-      //weightParams->push_back(vstring());
+      weightParams->push_back(vstring());
       for ( TXMLNode* weightNode = grpNode->GetChildren(); weightNode != 0; weightNode = weightNode->GetNextNode() )
       {
         if ( string(weightNode->GetNodeName()) != "weight" ) continue;
-        //weightParams->back().push_back(weightNode->GetText());
+        weightParams->back().push_back(weightNode->GetText());
         ++weightSize;
       }
       if ( weightIdxUB->empty() ) weightIdxUB->push_back(weightSize);
@@ -145,7 +146,7 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
 
   run.put(weightTypes, "weightTypes");
   run.put(weightIdxUB, "weightIdxUB");
-  //run.put(weightParams, "weightParams");
+  run.put(weightParams, "weightParams");
 }
 
 void GenWeightsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -45,7 +45,7 @@ private:
   const edm::EDGetTokenT<LHEEventProduct> lheToken_;
   const edm::EDGetTokenT<GenEventInfoProduct> genInfoToken_;
 
-  vint weightSizes_;
+  vint weightIdxUB_;
 };
 
 GenWeightsProducer::GenWeightsProducer(const edm::ParameterSet& pset):
@@ -63,7 +63,7 @@ GenWeightsProducer::GenWeightsProducer(const edm::ParameterSet& pset):
   }
 
   produces<vstring, edm::InRun>("weightTypes");
-  produces<vint, edm::InRun>("weightSizes");
+  produces<vint, edm::InRun>("weightIdxUB");
   //produces<vector<vstring>, edm::InRun>("weightParams");
 
   produces<float>("genWeight");
@@ -87,7 +87,7 @@ GenWeightsProducer::GenWeightsProducer(const edm::ParameterSet& pset):
 void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
 {
   std::auto_ptr<vstring> weightTypes(new vstring);
-  std::auto_ptr<vint> weightSizes(new vint);
+  std::auto_ptr<vint> weightIdxUB(new vint);
   //std::auto_ptr<vector<vstring> > weightParams(new vector<vstring>);
 
   do {
@@ -134,16 +134,17 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
         //weightParams->back().push_back(weightNode->GetText());
         ++weightSize;
       }
-      weightSizes->push_back(weightSize);
+      if ( weightIdxUB->empty() ) weightIdxUB->push_back(weightSize);
+      else weightIdxUB->push_back(weightIdxUB->back()+weightSize);
     }
 
   } while ( false );
 
-  weightSizes_.clear();
-  std::copy(weightSizes->begin(), weightSizes->end(), std::back_inserter(weightSizes_));
+  weightIdxUB_.clear();
+  std::copy(weightIdxUB->begin(), weightIdxUB->end(), std::back_inserter(weightIdxUB_));
 
   run.put(weightTypes, "weightTypes");
-  run.put(weightSizes, "weightSizes");
+  run.put(weightIdxUB, "weightIdxUB");
   //run.put(weightParams, "weightParams");
 }
 

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -20,10 +20,11 @@
 
 using namespace std;
 
-class GenWeightsProducer : public edm::stream::EDProducer<>
+class GenWeightsProducer : public edm::one::EDProducer<edm::BeginRunProducer>
 {
 public:
   GenWeightsProducer(const edm::ParameterSet& pset);
+  void beginRunProduce(edm::Run& run, const edm::EventSetup&) override;
   void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
@@ -62,6 +63,10 @@ GenWeightsProducer::GenWeightsProducer(const edm::ParameterSet& pset):
 
   LHAPDF::initPDFSet(1, pdfName_.c_str());
   if ( doReweightPdf_ ) LHAPDF::initPDFSet(2, generatedPdfName_.c_str());
+}
+
+void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
+{
 }
 
 void GenWeightsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -121,7 +121,7 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
     TXMLNode* topNode = xmlParser.GetXMLDocument()->GetRootNode();
     for ( TXMLNode* grpNode = topNode->GetChildren(); grpNode != 0; grpNode = grpNode->GetNextNode() )
     {
-      if ( string(grpNode->GetName()) != "weightgroup" ) continue;
+      if ( string(grpNode->GetNodeName()) != "weightgroup" ) continue;
       auto weightTypeObj = (TXMLAttr*)grpNode->GetAttributes()->FindObject("type");
       if ( !weightTypeObj ) continue;
 
@@ -130,7 +130,7 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
       //weightParams->push_back(vstring());
       for ( TXMLNode* weightNode = grpNode->GetChildren(); weightNode != 0; weightNode = weightNode->GetNextNode() )
       {
-        if ( string(weightNode->GetName()) != "weight" ) continue;
+        if ( string(weightNode->GetNodeName()) != "weight" ) continue;
         //weightParams->back().push_back(weightNode->GetText());
         ++weightSize;
       }

--- a/CatProducer/python/genWeight_cff.py
+++ b/CatProducer/python/genWeight_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 genWeight = cms.EDProducer("GenWeightsProducer",
+    doLOPDFReweight = cms.bool(False),
     enforceUnitGenWeight = cms.bool(False),
     lheEvent = cms.InputTag("externalLHEProducer"),
     genEventInfo = cms.InputTag("generator"),

--- a/CatProducer/python/genWeight_cff.py
+++ b/CatProducer/python/genWeight_cff.py
@@ -6,7 +6,5 @@ genWeight = cms.EDProducer("GenWeightsProducer",
     genEventInfo = cms.InputTag("generator"),
     pdfName = cms.string("NNPDF30_nlo_as_0118"),
     generatedPdfName = cms.string("NNPDF30_nlo_as_0118"),
-    lheWeightIndex = cms.int32(0),
-    genWeightIndex = cms.int32(0),
 )
 

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -28,6 +28,9 @@ namespace reco {
 
 namespace {
   struct CATTools_DataFormats {
+    std::vector<std::vector<std::string> > vvstr;
+    edm::Wrapper<std::vector<std::vector<std::string> > > vvstrw;
+    edm::Ptr<std::vector<std::vector<std::string> > > vvstrPtr;
 
     cat::Particle a_;
     std::vector<cat::Particle> av;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -1,4 +1,8 @@
 <lcgdict>
+  <class name="std::vector<std::vector<std::string> >" />
+  <class name="edm::Wrapper<std::vector<std::vector<std::string> > >" />
+  <class name="edm::Ptr<std::vector<std::vector<std::string> > >" />
+
 
   <class name="cat::Particle"/>
   <class name="std::vector<cat::Particle>"/>


### PR DESCRIPTION
#267

This is my first implementation to use weight group info from the LHE header.
Some basic information on weight group is added to the run information to be used later.

Actual grouping is not applied here, but since the name of weight group and the vector sizes are stored in the Run information, user may write own analyzer to split their group by combining information of "weightTypes" and "weightSizes".
