### PR TITLE
Safeguards to parse LHE xml

### DIFF
--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -110,10 +110,10 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
     if ( weightHeader == lheHandle->headers_end() ) break;
 
     // Read LHE using the XML parser
-    string contents = "<lhe>"; // Need root node
+    string contents = "<lhe>\n"; // Need root node
     contents.reserve(10000); // ~50 char per line, >100 weights
     for ( auto& line : weightHeader->lines() ) contents += line;
-    contents += "</lhe>"; // Close the root node
+    contents += "\n</lhe>\n"; // Close the root node
     TDOMParser xmlParser; xmlParser.SetValidate(false);
     xmlParser.ParseBuffer(contents.c_str(), contents.size());
     if ( !xmlParser.GetXMLDocument() ) break;

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -112,7 +112,12 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
     // Read LHE using the XML parser
     string contents = "<lhe>\n"; // Need root node
     contents.reserve(10000); // ~50 char per line, >100 weights
-    for ( auto& line : weightHeader->lines() ) contents += line;
+    for ( auto line : weightHeader->lines() )
+    {
+      line = line.substr(line.find_first_not_of(" \t\r\t"), line.find_last_not_of(" \n\r\t"));
+      if ( line.empty() or line[0] != '<' or line[line.size()-1] != '>' ) continue;
+      contents += line + "\n";
+    }
     contents += "\n</lhe>\n"; // Close the root node
     TDOMParser xmlParser; xmlParser.SetValidate(false);
     xmlParser.ParseBuffer(contents.c_str(), contents.size());

--- a/CatProducer/test/testGenWeight_cfg.py
+++ b/CatProducer/test/testGenWeight_cfg.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("Ana")
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("CATTools.CatProducer.genWeight_cff")
+
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(False),
+    allowUnscheduled = cms.untracked.bool(True),
+)
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
+process.source.fileNames = [
+'file:/cms/scratch/jlee/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v2/00C4781D-6B08-E511-8A0A-0025905A6084.root',
+]
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string("out.root"),
+    outputCommands = cms.untracked.vstring(
+        "drop *",
+        "keep *_genWeight_*_*",
+    )
+)
+process.outPath = cms.EndPath(process.out)


### PR DESCRIPTION
Adds newline before xml file for the LHE header parsing.
This "might" bypass the problem of invalid xml syntax issue such as `<</lhe>`.
