### PR TITLE
Filter event by weight threshold

### DIFF
--- a/CatAnalyzer/plugins/EventWeightThresholdFilter.cc
+++ b/CatAnalyzer/plugins/EventWeightThresholdFilter.cc
@@ -1,0 +1,77 @@
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <vector>
+#include <string>
+
+class EventWeightThresholdFilter : public edm::stream::EDFilter<>
+{
+public:
+  EventWeightThresholdFilter(const edm::ParameterSet& pset);
+  bool filter(edm::Event& event, const edm::EventSetup&) override;
+
+private:
+  //typedef std::vector<bool> vbool;
+  //typedef std::vector<int> vint;
+  typedef std::vector<std::string> strings;
+  bool combineByOr_;
+
+  const bool isLessThan_;
+  const double threshold_;
+  edm::EDGetTokenT<double> weightToken_;
+  edm::EDGetTokenT<float> weightTokenF_;
+  edm::EDGetTokenT<int> weightTokenI_;
+
+  enum class TYPE { D, F, I } type_;
+
+};
+
+EventWeightThresholdFilter::EventWeightThresholdFilter(const edm::ParameterSet& pset):
+  isLessThan_(pset.getParameter<bool>("isLessThan")),
+  threshold_(pset.getParameter<double>("threshold"))
+{
+  const auto typeStr = pset.getParameter<std::string>("type");
+  if ( typeStr == "double" ) {
+    type_ = TYPE::D;
+    weightToken_ = consumes<double>(pset.getParameter<edm::InputTag>("src"));
+  }
+  else if ( typeStr == "float" ) {
+    type_ = TYPE::F;
+    weightTokenF_ = consumes<float>(pset.getParameter<edm::InputTag>("src"));
+  }
+  else if ( typeStr == "int" ) {
+    type_ = TYPE::I;
+    weightTokenI_ = consumes<int>(pset.getParameter<edm::InputTag>("src"));
+  }
+  else edm::LogError("EventWeightThresholdFilter") << "Wrong input to \"type\" option, it was \"" << typeStr << ".\n"
+                                              << "This should be chosen among (\"double\", \"float\", \"int\")\n";
+
+}
+
+bool EventWeightThresholdFilter::filter(edm::Event& event, const edm::EventSetup&)
+{
+  using namespace std;
+
+  double w = -1;
+  if ( type_ == TYPE::D ) {
+    edm::Handle<double> handle;
+    event.getByToken(weightToken_, handle);
+    w = *handle;
+  }
+  else if ( type_ == TYPE::F ) {
+    edm::Handle<float> handle;
+    event.getByToken(weightTokenF_, handle);
+    w = *handle;
+  }
+  else if ( type_ == TYPE::I ) {
+    edm::Handle<int> handle;
+    event.getByToken(weightTokenI_, handle);
+    w = *handle;
+  }
+
+  if ( isLessThan_ ) return w < threshold_;
+  return w >= threshold_;
+}
+
+DEFINE_FWK_MODULE(EventWeightThresholdFilter);

--- a/CatAnalyzer/python/filters_cff.py
+++ b/CatAnalyzer/python/filters_cff.py
@@ -1,5 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
+filterLumi = cms.EDFilter("EventWeightThresholdFilter",
+    isLessThan = cms.bool(False),
+    threshold = cms.double(0.5), # Require >= 0.5 to select events with bit=1
+    type = cms.string("int"),
+    src = cms.InputTag("lumiMask"),
+)
+
+filterLumiSilver = filterLumi.clone(src = cms.InputTag("lumiMaskSilver"))
+
 filterRECO = cms.EDFilter("CATTriggerBitCombiner",
     triggerResults = cms.InputTag("TriggerResults::PAT"),
     secondaryTriggerResults = cms.InputTag("TriggerResults::RECO"),

--- a/CatAnalyzer/test/TTLL/analyze_data_cfg.py
+++ b/CatAnalyzer/test/TTLL/analyze_data_cfg.py
@@ -10,9 +10,8 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 50000
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.fileNames = [
-    '/store/group/CAT/TT_TuneCUETP8M1_13TeV-powheg-pythia8/v7-4-6_RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/151127_200613/0000/catTuple_82.root'
+    '/store/group/CAT/MuonEG/v7-4-6_Run2015D-PromptReco-v4/151127_195257/0000/catTuple_1.root'
 ]
-#process.source.fileNames.append('/store/group/CAT/DoubleMuon/v7-4-4_Run2015C_25ns-05Oct2015-v1/151023_165157/0000/catTuple_10.root')
 
 process.load("CATTools.CatAnalyzer.filters_cff")
 process.load("CATTools.CatAnalyzer.ttll.ttllEventSelector_cfi")
@@ -24,7 +23,7 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string("hist.root"),
 )
 
-process.p = cms.Path(process.ttll)#*process.ntuple)
+process.p = cms.Path(process.filterLumi*process.ttll)#*process.ntuple)
 
 ## Customise with cmd arguments
 import sys


### PR DESCRIPTION
A filter module is added to select event weight.
The main use case is to apply filter to the "lumiMask" in the event.

``` python
process.filterLumi = cms.EDFilter("EventWeightThresholdFilter",
    isLessThan = cms.bool(False),
    threshold = cms.double(0.5), # Require >= 0.5 to select events with bit=1
    type = cms.string("int"),
    src = cms.InputTag("lumiMask"),
)
```
