### PR TITLE
Additional ID bit for triggered MVA preselection 

### DIFF
--- a/CatAnalyzer/plugins/TTLLEventSelector.cc
+++ b/CatAnalyzer/plugins/TTLLEventSelector.cc
@@ -480,10 +480,8 @@ private:
   }
   bool isGoodElectron(const cat::Electron& el)
   {
-    const double aeta = std::abs(el.eta());
-    if ( aeta > 2.4 ) return false;
-    const double pt = shiftedElectronPt(el);
-    if ( pt < 20 ) return false;
+    if ( std::abs(el.eta()) > 2.4 ) return false;
+    if ( shiftedElectronPt(el) < 20 ) return false;
 
     if ( !el.isTrigMVAValid() ) return false;
 

--- a/CatAnalyzer/plugins/TTLLEventSelector.cc
+++ b/CatAnalyzer/plugins/TTLLEventSelector.cc
@@ -480,8 +480,12 @@ private:
   }
   bool isGoodElectron(const cat::Electron& el)
   {
-    if ( std::abs(el.eta()) > 2.4 ) return false;
-    if ( shiftedElectronPt(el) < 20 ) return false;
+    const double aeta = std::abs(el.eta());
+    if ( aeta > 2.4 ) return false;
+    const double pt = shiftedElectronPt(el);
+    if ( pt < 20 ) return false;
+
+    if ( !el.isTrigMVAValid() ) return false;
 
     //if ( el.relIso(0.3) >= 0.11 ) return false;
     if ( !el.electronID(elIdName_) ) return false;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -805,7 +805,7 @@ float TtbarDiLeptonAnalyzer::selectElecs(const cat::ElectronCollection& elecs, P
     if ((std::abs(el.scEta()) > 1.4442) && (std::abs(el.scEta()) < 1.566)) continue;
     if (std::abs(el.eta()) > 2.4) continue;
     //if ( !el.electronID("cutBasedElectronID-Spring15-25ns-V1-standalone-medium") ) continue;
-    if ( !el.electronID("mvaEleID-Spring15-25ns-Trig-V1-wp90") ) continue;
+    if ( !el.isTrigMVAValid() or !el.electronID("mvaEleID-Spring15-25ns-Trig-V1-wp90") ) continue;
     if (el.relIso(0.3) > 0.12) continue;
 
     weight *= el.scaleFactor("mvaEleID-Spring15-25ns-Trig-V1-wp90");

--- a/CatProducer/plugins/CATElectronProducer.cc
+++ b/CatProducer/plugins/CATElectronProducer.cc
@@ -194,6 +194,36 @@ cat::CATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
 
     aElectron.setSNUID(snu_id);
 
+    // Fill the validity flag of triggered MVA
+    bool isTrigMVAValid = false;
+    if ( pt > 15 ) {
+      const double abseta = std::abs(aElectron.eta());
+      const double full5x5_sigIetaIeta = aPatElectron.full5x5_sigmaIetaIeta();
+      const double hcalOverEcal =  aPatElectron.hcalOverEcal();
+      const double ecalPFClusterIso = aPatElectron.ecalPFClusterIso();
+      const double hcalPFClusterIso = aPatElectron.hcalPFClusterIso();
+      const double dr03TkSumPt = aPatElectron.dr03TkSumPt();
+      if ( abseta < 1.479 ) { // Barrel
+        const double deltaEtaSuperClusterTrackAtVtx = aPatElectron.deltaEtaSuperClusterTrackAtVtx();
+        const double deltaPhiSuperClusterTrackAtVtx = aPatElectron.deltaPhiSuperClusterTrackAtVtx();
+        if ( full5x5_sigmaIetaIeta < 0.012 and
+             hcalOverEcal < 0.09 and
+             ecalPFClusterIso < 0.37*pt and
+             hcalPFClusterIso < 0.25*pt and
+             dr03TkSumPt < 0.18*pt and
+             std::abs(deltaEtaSuperClusterTrackAtVtx) < 0.0095 and
+             std::abs(deltaPhiSuperClusterTrackAtVtx) < 0.065 ) isTrigMVAValid = true;
+      }
+      else { // Endcap
+        if ( full5x5_sigmaIetaIeta < 0.033 and
+             hcalOverEcal < 0.09 and
+             ecalPFClusterIso < 0.45*pt and
+             hcalPFClusterIso < 0.28*pt and
+             dr03TkSumPt < 0.18*pt ) isTrigMVAValid = true;
+      }
+    }
+    aElectron.setTrigMVAValid(isTrigMVAValid);
+
     out->push_back(aElectron);
 
     ++j;

--- a/DataFormats/interface/Electron.h
+++ b/DataFormats/interface/Electron.h
@@ -44,6 +44,7 @@ namespace cat {
     float shiftedEnUp() const {return  1+shiftedEn();}
     
     int snuID() const {return snuID_;}
+    bool isTrigMVAValid() const { return isTrigMVAValid_; }
     
     void setElectronIDs(const std::vector<pat::Electron::IdPair> & ids) { electronIDs_ = ids; }
     void setElectronID(pat::Electron::IdPair ids) { electronIDs_.push_back(ids); }
@@ -60,6 +61,7 @@ namespace cat {
     void setIsEB(bool d) { isEB_ = d ; }
 
     void setSNUID(int id) {snuID_ = id;}
+    void setTrigMVAValid(bool val) { isTrigMVAValid_ = val; }
 
     float scaleFactor(const std::string& name, int sign = 0) const;
     
@@ -76,6 +78,7 @@ namespace cat {
     bool isEB_;
     
     int snuID_;
+    bool isTrigMVAValid_;
   };
 }
 


### PR DESCRIPTION
Description given in the issue #347.

According to the reference https://twiki.cern.ch/twiki/bin/viewauth/CMS/MultivariateElectronIdentificationRun2 , preselection cuts have to be applied for the electron triggered MVA. Otherwise, it wil show undefined behaviour.
