### PR TITLE
Fixed GenWeight groups

### DIFF
--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -92,6 +92,7 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
   vstring weightTypes;
   vvstring weightParams;
   scaleWeightIdxs_.clear();
+  pdfWeightIdxs_.clear();
 
   std::auto_ptr<string> combineScaleBy(new string);
   std::auto_ptr<string> combinePDFBy(new string);
@@ -138,7 +139,8 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
     for ( TXMLNode* grpNode = topNode->GetChildren(); grpNode != 0; grpNode = grpNode->GetNextNode() )
     {
       if ( string(grpNode->GetNodeName()) != "weightgroup" ) continue;
-      auto weightTypeObj = (TXMLAttr*)grpNode->GetAttributes()->FindObject("type");
+      auto weightTypeObj = (TXMLAttr*)grpNode->GetAttributes()->FindObject("name");
+      if ( !weightTypeObj ) weightTypeObj = (TXMLAttr*)grpNode->GetAttributes()->FindObject("type"); // FIXME: this may not needed - double check LHE header doc.
       if ( !weightTypeObj ) continue;
 
       weightTypes.push_back(weightTypeObj->GetValue());


### PR DESCRIPTION
GenWeights are not in correct place, tested with 76X MiniAOD, powheg and aMC@NLO

Note for analyzers : "otherWeights" are not empty since there are yet another variation called "hdamp" variation. There can be even more but let us not consider them for now.
