### PR TITLE
Include central weight at the first of all weight variations

### DIFF
--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -247,7 +247,7 @@ void GenWeightsProducer::produce(edm::Event& event, const edm::EventSetup& event
   {
     if ( lheHandle.isValid() )
     {
-      for ( size_t i=1; i<lheHandle->weights().size(); ++i )
+      for ( size_t i=0; i<lheHandle->weights().size(); ++i )
       {
         const double w0 = lheHandle->weights().at(i).wgt;
         const double w = w0/(enforceUnitGenWeight_ ? std::abs(lheWeight) : originalWeight);
@@ -258,7 +258,7 @@ void GenWeightsProducer::produce(edm::Event& event, const edm::EventSetup& event
     }
     else
     {
-      for ( size_t i=1; i<genInfoHandle->weights().size(); ++i )
+      for ( size_t i=0; i<genInfoHandle->weights().size(); ++i )
       {
         const double w0 = genInfoHandle->weights().at(i);
         const double w = w0/(enforceUnitGenWeight_ ? std::abs(genWeight) : originalWeight);


### PR DESCRIPTION
Keep the 0th element of weight group.
This can be a duplication of information, but it gives uniform structure for all variations.

Therefore, genWeight:genWeight = genWeight:scaleWeights[0] = genWeight:pdfWeights[0] = genWeight:otherWeights[0](if exists)
