### PR TITLE
Keep inheritence information

### DIFF
--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -46,15 +46,17 @@ private:
   void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&) override;
   void endLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override {};
 
+  typedef std::vector<const cat::Lepton*> LeptonPtrs;
+
   void resetBr();
-  float selectMuons(const cat::MuonCollection& muons, ParticleCollection& selmuons, sys_e sys) const;
-  float selectElecs(const cat::ElectronCollection& elecs, ParticleCollection& selelecs, sys_e sys) const;
-  cat::JetCollection selectJets(const cat::JetCollection& jets, const ParticleCollection& recolep, sys_e sys);
+  float selectMuons(const cat::MuonCollection& muons, cat::MuonCollection& selmuons, sys_e sys) const;
+  float selectElecs(const cat::ElectronCollection& elecs, cat::ElectronCollection& selelecs, sys_e sys) const;
+  cat::JetCollection selectJets(const cat::JetCollection& jets, const LeptonPtrs& recolep, sys_e sys);
   cat::JetCollection selectBJets(const cat::JetCollection& jets) const;
   const reco::Candidate* getLast(const reco::Candidate* p) const;
 
   ScaleFactorEvaluator muonSF_, elecSF_;
-  float getSF(const cat::Particle& p, int sys) const
+  float getSF(const cat::Lepton& p, int sys) const
   {
     const int aid = abs(p.pdgId());
     if ( aid == 13 ) {
@@ -615,20 +617,25 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     edm::Handle<cat::METCollection> mets;            iEvent.getByToken(metToken_, mets);
 
     // Find leptons and sort by pT
-    ParticleCollection recolep;
-    selectMuons(*muons, recolep, (sys_e)sys);
-    selectElecs(*electrons, recolep, (sys_e)sys);
+    cat::MuonCollection selMuons;
+    cat::ElectronCollection selElecs;
+    selectMuons(*muons, selMuons, (sys_e)sys);
+    selectElecs(*electrons, selElecs, (sys_e)sys);
     //b_lepweight = mu_weight * el_weight;
-    if (recolep.size() < 2){
+    if ( selMuons.size()+selElecs.size() < 2 ) {
       ttree_[sys]->Fill();
       continue;
     }
     cutflow_[3][b_channel]++;
 
-    sort(recolep.begin(), recolep.end(), GtByCandPt());
+    std::vector<const cat::Lepton*> recolep;
+    for ( const auto& x : selMuons ) recolep.push_back(&x);
+    for ( const auto& x : selElecs ) recolep.push_back(&x);
+
+    sort(recolep.begin(), recolep.end(), [](const cat::Lepton* a, const cat::Lepton* b){return a->pt() > b->pt();});
     recolep.erase(recolep.begin()+2,recolep.end());
-    const cat::Particle& recolep1 = recolep[0];
-    const cat::Particle& recolep2 = recolep[1];
+    const cat::Lepton& recolep1 = *recolep[0];
+    const cat::Lepton& recolep2 = *recolep[1];
 
     // Determine channel
     const int pdgIdSum = std::abs(recolep1.pdgId()) + std::abs(recolep2.pdgId());
@@ -801,7 +808,7 @@ const reco::Candidate* TtbarDiLeptonAnalyzer::getLast(const reco::Candidate* p) 
   return p;
 }
 
-float TtbarDiLeptonAnalyzer::selectMuons(const cat::MuonCollection& muons, ParticleCollection& selmuons, sys_e sys) const
+float TtbarDiLeptonAnalyzer::selectMuons(const cat::MuonCollection& muons, cat::MuonCollection& selmuons, sys_e sys) const
 {
   float weight = 1.;
   for (auto& m : muons) {
@@ -821,7 +828,7 @@ float TtbarDiLeptonAnalyzer::selectMuons(const cat::MuonCollection& muons, Parti
   return weight;
 }
 
-float TtbarDiLeptonAnalyzer::selectElecs(const cat::ElectronCollection& elecs, ParticleCollection& selelecs, sys_e sys) const
+float TtbarDiLeptonAnalyzer::selectElecs(const cat::ElectronCollection& elecs, cat::ElectronCollection& selelecs, sys_e sys) const
 {
   float weight = 1.;
   for (auto& e : elecs) {
@@ -844,7 +851,7 @@ float TtbarDiLeptonAnalyzer::selectElecs(const cat::ElectronCollection& elecs, P
   return weight;
 }
 
-cat::JetCollection TtbarDiLeptonAnalyzer::selectJets(const cat::JetCollection& jets, const ParticleCollection& recolep, sys_e sys)
+cat::JetCollection TtbarDiLeptonAnalyzer::selectJets(const cat::JetCollection& jets, const TtbarDiLeptonAnalyzer::LeptonPtrs& recolep, sys_e sys)
 {
   cat::JetCollection seljets;
   for (auto& j : jets) {
@@ -860,7 +867,7 @@ cat::JetCollection TtbarDiLeptonAnalyzer::selectJets(const cat::JetCollection& j
 
     bool hasOverLap = false;
     for (auto lep : recolep){
-      if (deltaR(jet.p4(),lep.p4()) < 0.4) hasOverLap = true;
+      if (deltaR(jet.p4(),lep->p4()) < 0.4) hasOverLap = true;
     }
     if (hasOverLap) continue;
     // printf("jet with pt %4.1f\n", jet.pt());


### PR DESCRIPTION
SelectMuons and SelectElecs functions saved selected leptons in LeptonCollection for simplicity but this looses inheritance information thus calling dynamic_cast failed.

In this fix, those functions stores selected object in the collections with same type and their pointers are uses in pT ordering.
