### PR TITLE
Dilepton trigger scale factors

### DIFF
--- a/CatAnalyzer/plugins/TtbarBbbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarBbbarDiLeptonAnalyzer.cc
@@ -122,7 +122,8 @@ private:
   TTree * ttree15_;
   
   int b_nvertex, b_step, b_channel;
-  bool b_step1, b_step2, b_step3, b_step4, b_step5, b_step6, b_tri, b_filtered;
+  bool b_step1, b_step2, b_step3, b_step4, b_step5, b_step6, b_filtered;
+  float b_tri;
   float b_met, b_metphi;
   int b_njet30, b_nbjetL30, b_nbjetM30, b_nbjetT30;
   int b_nbjetL30MVA, b_nbjetM30MVA, b_nbjetT30MVA;
@@ -383,7 +384,7 @@ void TtbarBbbarDiLeptonAnalyzer::book(TTree* tree){
   tree->Branch("step4", &b_step4, "step4/O");
   tree->Branch("step5", &b_step5, "step5/O");
   tree->Branch("step6", &b_step6, "step6/O");
-  tree->Branch("tri", &b_tri, "tri/O");
+  tree->Branch("tri", &b_tri, "tri/F");
   tree->Branch("filtered", &b_filtered, "filtered/O");
   tree->Branch("met", &b_met, "met/F");
   tree->Branch("metphi", &b_metphi, "metphi/F");
@@ -859,12 +860,22 @@ void TtbarBbbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
     if (pdgIdSum == 26) b_channel = CH_MUMU; // mumu
     
     // Trigger results
+    // Scale factors are from AN16-025 (v4) http://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2016_025_v4.pdf
+    b_tri = 0;
     edm::Handle<int> trigHandle;
-    if      ( b_channel == CH_ELEL ) iEvent.getByToken(trigTokenELEL_, trigHandle);
-    else if ( b_channel == CH_MUMU ) iEvent.getByToken(trigTokenMUMU_, trigHandle);
-    else if ( b_channel == CH_MUEL ) iEvent.getByToken(trigTokenMUEL_, trigHandle);
-    b_tri = *trigHandle;
-    
+    if ( b_channel == CH_ELEL ) {
+      iEvent.getByToken(trigTokenELEL_, trigHandle);
+      if ( *trigHandle != 0 ) b_tri = 0.953; // +- 0.009
+    }
+    else if ( b_channel == CH_MUMU ) {
+      iEvent.getByToken(trigTokenMUMU_, trigHandle);
+      if ( *trigHandle != 0 ) b_tri = 0.948; // +- 0.002
+    }
+    else if ( b_channel == CH_MUEL ) {
+      iEvent.getByToken(trigTokenMUEL_, trigHandle);
+      if ( *trigHandle != 0 ) b_tri = 0.975; // +- 0.004
+    }
+
     b_lep1_pt = recolep1.pt(); b_lep1_eta = recolep1.eta(); b_lep1_phi = recolep1.phi(); b_lep1_q = recolep1.charge();
     b_lep2_pt = recolep2.pt(); b_lep2_eta = recolep2.eta(); b_lep2_phi = recolep2.phi(); b_lep2_q = recolep2.charge();
     
@@ -1160,7 +1171,8 @@ void TtbarBbbarDiLeptonAnalyzer::resetBrReco()
   b_njet30 = 0;
   b_nbjetL30=0, b_nbjetM30 = 0; b_nbjetT30 = 0;
   b_nbjetL30MVA=0, b_nbjetM30MVA = 0; b_nbjetT30MVA = 0;
-  b_step1 = 0;b_step2 = 0;    b_step3 = 0;b_step4 = 0;b_step5 = 0;b_step6 = 0;b_tri = 0;
+  b_step1 = 0;b_step2 = 0;    b_step3 = 0;b_step4 = 0;b_step5 = 0;b_step6 = 0;
+  b_tri = 0;
   b_met = -9; b_metphi = -9;
 
   b_lepweight = 1;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -657,6 +657,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     b_lepweight = getSF(recolep1, sys)*getSF(recolep2, sys);
 
     // Trigger results
+    // Scale factors are from AN16-025 (v4) http://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2016_025_v4.pdf
     b_tri = 0;
     edm::Handle<int> trigHandle;
     if ( b_channel == CH_ELEL ) {

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -97,7 +97,8 @@ private:
 
   std::vector<TTree*> ttree_;
   int b_nvertex, b_step, b_channel, b_njet, b_nbjet;
-  bool b_step1, b_step2, b_step3, b_step4, b_step5, b_step6, b_tri, b_filtered;
+  bool b_step1, b_step2, b_step3, b_step4, b_step5, b_step6, b_filtered;
+  float b_tri;
   float b_met, b_weight, b_puweight, b_puweight_up, b_puweight_dn, b_genweight, b_lepweight, b_btagweight, b_btagweight_up, b_btagweight_dn;
   float b_topPtWeight;
   std::vector<float> b_pdfWeights, b_scaleWeights, b_csvweights;
@@ -234,7 +235,7 @@ TtbarDiLeptonAnalyzer::TtbarDiLeptonAnalyzer(const edm::ParameterSet& iConfig)
     tr->Branch("step4", &b_step4, "step4/O");
     tr->Branch("step5", &b_step5, "step5/O");
     tr->Branch("step6", &b_step6, "step6/O");
-    tr->Branch("tri", &b_tri, "tri/O");
+    tr->Branch("tri", &b_tri, "tri/F");
     tr->Branch("filtered", &b_filtered, "filtered/O");
     tr->Branch("met", &b_met, "met/F");
     tr->Branch("weight", &b_weight, "weight/F");
@@ -656,11 +657,20 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     b_lepweight = getSF(recolep1, sys)*getSF(recolep2, sys);
 
     // Trigger results
+    b_tri = 0;
     edm::Handle<int> trigHandle;
-    if      ( b_channel == CH_ELEL ) iEvent.getByToken(trigTokenELEL_, trigHandle);
-    else if ( b_channel == CH_MUMU ) iEvent.getByToken(trigTokenMUMU_, trigHandle);
-    else if ( b_channel == CH_MUEL ) iEvent.getByToken(trigTokenMUEL_, trigHandle);
-    b_tri = *trigHandle;
+    if ( b_channel == CH_ELEL ) {
+      iEvent.getByToken(trigTokenELEL_, trigHandle);
+      if ( *trigHandle != 0 ) b_tri = 0.953; // +- 0.009
+    }
+    else if ( b_channel == CH_MUMU ) {
+      iEvent.getByToken(trigTokenMUMU_, trigHandle);
+      if ( *trigHandle != 0 ) b_tri = 0.948; // +- 0.002
+    }
+    else if ( b_channel == CH_MUEL ) {
+      iEvent.getByToken(trigTokenMUEL_, trigHandle);
+      if ( *trigHandle != 0 ) b_tri = 0.975; // +- 0.004
+    }
 
     b_lep1_pt = recolep1.pt(); b_lep1_eta = recolep1.eta(); b_lep1_phi = recolep1.phi();
     b_lep2_pt = recolep2.pt(); b_lep2_eta = recolep2.eta(); b_lep2_phi = recolep2.phi();


### PR DESCRIPTION
Dilepton trigger scale factors are added, the scale factors are based on AN-2016/025 v4 by Till. (http://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2016/025)

It applies single number for each datasets. In the catTools, the factors are stored while producing ntuples - use the b_tri to save the SFs.

To be done by analyzers - update the ttree drawer macros to treat "tri" branch as one of the weights while projecting to histograms.
