### PR TITLE
Top kin reco bugfix

### DIFF
--- a/CatAnalyzer/src/KinematicSolvers.cc
+++ b/CatAnalyzer/src/KinematicSolvers.cc
@@ -353,6 +353,8 @@ void DESYSmearedSolver::solve(const LV input[])
         std::copy(nu1solTmp, nu1solTmp+4, nu1sol);
         std::copy(nu2solTmp, nu2solTmp+4, nu2sol);
       }
+
+      break; // The DESY implementaion just takes first solution. Strange, even commented in their code
     }
     if ( minMTTsqr < 0 ) continue;
 
@@ -385,8 +387,10 @@ LV DESYSmearedSolver::getSmearedLV(const LV& lv0,
   const double p = sqrt(std::max(0., e*e-lv0.M2()));
   if ( KinSolverUtils::isZero(e) or KinSolverUtils::isZero(p) ) return LV();
 
-  const double px0 = lv0.px(), py0 = lv0.py(), pz0 = lv0.pz();
-  if ( px0 == 0 and py0 == 0 and pz0 == 0 ) return lv0;
+  const double px0 = std::abs(lv0.px()) < 0.001 ? 0 : lv0.px();
+  const double py0 = std::abs(lv0.py()) < 0.001 ? 0 : lv0.py();
+  const double pz0 = std::abs(lv0.pz()) < 0.001 ? 0 : lv0.pz();
+  if ( p == 0 ) return LV(0, 0, 0, e);
 
   // Apply rotation
   const double localPhi = 2*TMath::Pi()*rng_->flat();

--- a/CatAnalyzer/src/KinematicSolvers.cc
+++ b/CatAnalyzer/src/KinematicSolvers.cc
@@ -353,8 +353,6 @@ void DESYSmearedSolver::solve(const LV input[])
         std::copy(nu1solTmp, nu1solTmp+4, nu1sol);
         std::copy(nu2solTmp, nu2solTmp+4, nu2sol);
       }
-
-      break; // The DESY implementaion just takes first solution. Strange, even commented in their code
     }
     if ( minMTTsqr < 0 ) continue;
 
@@ -417,7 +415,7 @@ double DESYSmearedSolver::getRandom(TH1* h)
 {
   if ( !h ) return 0;
 
-  h->GetRandom();
+  //h->GetRandom();
   const int n = h->GetNbinsX();
   const double* fIntegral = h->GetIntegral();
   const double integral = fIntegral[n];

--- a/CatAnalyzer/src/KinematicSolvers.cc
+++ b/CatAnalyzer/src/KinematicSolvers.cc
@@ -382,7 +382,7 @@ LV DESYSmearedSolver::getSmearedLV(const LV& lv0,
 {
   // Rescale at the first step
   const double e = fE*lv0.energy();
-  const double p = sqrt(std::max(0., e*e-lv0.M2()));
+  const double p = std::sqrt(std::max(0., e*e-lv0.M2()));
   if ( KinSolverUtils::isZero(e) or KinSolverUtils::isZero(p) ) return LV();
 
   const double px0 = std::abs(lv0.px()) < 0.001 ? 0 : lv0.px();
@@ -396,13 +396,13 @@ LV DESYSmearedSolver::getSmearedLV(const LV& lv0,
   const double py1 =  p*sin(dRot)*cos(localPhi);
   const double pz1 =  p*cos(dRot);
 
-  if ( py0 == 0 and pz0 == 0 ) return LV(px1, py1, pz1, e);
+  if ( py0 == 0 and pz0 == 0 ) return LV(pz1, px1, py1, e);
 
   const double d = hypot(pz0, py0);
 
-  const double x1 =  d/p        , y1 = 0    , z1 = px0/p;
-  const double x2 = -px0*py0/d/p, y2 = pz0/d, z2 = py0/p;
-  const double x3 = -px0*pz0/d/p, y3 = py0/d, z3 = pz0/p;
+  const double x1 =  d/p        , y1 =  0    , z1 = px0/p;
+  const double x2 = -px0*py0/d/p, y2 =  pz0/d, z2 = py0/p;
+  const double x3 = -px0*pz0/d/p, y3 = -py0/d, z3 = pz0/p;
 
   const double px = x1*px1 + y1*py1 + z1*pz1;
   const double py = x2*px1 + y2*py1 + z2*pz1;

--- a/CatAnalyzer/src/TopKinSolverUtils.cc
+++ b/CatAnalyzer/src/TopKinSolverUtils.cc
@@ -48,7 +48,7 @@ void KinSolverUtils::findCoeffs(const double mT, const double mW1, const double 
   const double a14 = a1/a4, a24 = a2/a4, a34 = a3/a4;
   const double c00 = -4*(dxsqr(l1E, l1.py()) + dxsqr(l1E, l1.pz())*a34*a34 + 2*l1.py()*l1.pz()*a34)/divC;
   const double c10 = -8*(dxsqr(l1E, l1.pz())*a24*a34 - l1.px()*l1.py() + l1.px()*l1.pz()*a34 + l1.py()*l1.pz()*a24)/divC;
-  const double c20 = -4*(dxsqr(l1E, l1.px()) + dxsqr(l1E, l1.pz())*sqr(a2/a4) + 2*l1.px()*l1.pz()*a24)/divC; 
+  const double c20 = -4*(dxsqr(l1E, l1.px()) + dxsqr(l1E, l1.pz())*a24*a24 + 2*l1.px()*l1.pz()*a24)/divC;
   const double c11 = 4*(dmW1*(l1.py()-l1.pz()*a34)-2*dxsqr(l1E, l1.pz())*a14*a34-2*l1.py()*l1.pz()*a14)/divC;
   const double c21 = 4*(dmW1*(l1.px()-l1.pz()*a24)-2*dxsqr(l1E, l1.pz())*a14*a24-2*l1.px()*l1.pz()*a14)/divC;
   const double c22 = (dmW1*dmW1-4*dxsqr(l1E, l1.pz())*a14*a14-4*dmW1*l1.pz()*a14)/divC;
@@ -181,7 +181,7 @@ void KinSolverUtils::solve_quartic(const std::vector<double>& h,
 
   const double h0 = h[0], h1 = h[1], h2 = h[2], h3 = h[3], h4 = h[4];
   if ( isZero(h0) ) return solve_cubic(h1, h2, h3, h4, v);
-  if ( isZero(h3) ) {
+  if ( isZero(h4) ) {
     solve_cubic(h0, h1, h2, h3, v);
     v.push_back(0);
     return;


### PR DESCRIPTION
This PR contains some bugfixes for the top kinematic reconstruction. 
- Minor fix for special cases to solve quadratic equation
- Major fix to apply angular smearing, some typo gave wrong x-y-z direction, causing large difference in eta/phi
