### PR TITLE
Gen jet hadron matching information with decay history

### DIFF
--- a/CatProducer/plugins/CATGenJetProducer.cc
+++ b/CatProducer/plugins/CATGenJetProducer.cc
@@ -3,20 +3,11 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/Common/interface/Association.h"
-#include "DataFormats/Common/interface/RefToPtr.h"
-
-#include "DataFormats/JetReco/interface/GenJetCollection.h"
-#include "DataFormats/JetReco/interface/GenJet.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "CATTools/DataFormats/interface/GenJet.h"
 #include "CATTools/DataFormats/interface/MCParticle.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
-#include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
+
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/ClusterSequence.hh"
 
 using namespace edm;
 using namespace std;
@@ -32,8 +23,10 @@ namespace cat {
 
   private:
     edm::EDGetTokenT<reco::GenJetCollection> src_;
+    edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
     const double pt_;
     const double eta_;
+    std::shared_ptr<fastjet::JetDefinition> fjDef_;
 
     std::vector<const reco::Candidate *> getAncestors(const reco::Candidate &c);
     bool hasBottom(const reco::Candidate &c);
@@ -42,6 +35,7 @@ namespace cat {
     bool decayFromCHadron(const reco::Candidate &c);
     const reco::Candidate* lastBHadron(const reco::Candidate &c);
     const reco::Candidate* lastCHadron(const reco::Candidate &c);
+    int getFlavour(const int pdgId);
 
   };
 
@@ -49,51 +43,141 @@ namespace cat {
 
 cat::CATGenJetProducer::CATGenJetProducer(const edm::ParameterSet & iConfig) :
   src_(consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+  genParticlesToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
   pt_(iConfig.getParameter<double>("pt")),
-  eta_(iConfig.getParameter<double>("eta"))
+  eta_(iConfig.getParameter<double>("eta")),
+  fjDef_(std::shared_ptr<fastjet::JetDefinition>(new fastjet::JetDefinition(fastjet::antikt_algorithm, 0.4)))
 {
   produces<std::vector<cat::GenJet> >();
 }
 
-void
-cat::CATGenJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
+void cat::CATGenJetProducer::produce(edm::Event & iEvent, const edm::EventSetup&)
 {
+  auto_ptr<vector<cat::GenJet> >  out(new vector<cat::GenJet>());
+
+  // Collect heavy-flavour hadrons
+  edm::Handle<reco::GenParticleCollection> genParticlesHandle;
+  iEvent.getByToken(genParticlesToken_, genParticlesHandle);
+  std::set<size_t> bHadrons, cHadrons;
+  for ( size_t i=0, n=genParticlesHandle->size(); i<n; ++i ) {
+    const auto& x = genParticlesHandle->at(i);
+    if ( x.status() == 1 or x.status() == 4 ) continue; // Skip final states and incident beams
+
+    const int aid = abs(x.pdgId());
+    if ( aid < 100 ) continue; // Skip partons
+
+    const int nDau = x.numberOfDaughters();
+    if ( nDau == 0 ) continue; // Skip final states, just for confirmation
+    if ( !x.isLastCopy() ) continue; // Consider the last copy only
+
+    const int flav = getFlavour(aid);
+    if ( flav < 4 ) continue;
+
+    bool isLast = true;
+    for ( int i=0; i<nDau; ++i ) {
+      const int dauFlav = getFlavour(x.daughter(i)->pdgId());
+      if ( flav == dauFlav ) { isLast = false; break; }
+    }
+    if ( !isLast ) continue; // Keep last hadrons only
+
+    if      ( flav == 5 ) bHadrons.insert(i);
+    else if ( flav == 4 ) cHadrons.insert(i);
+  }
+  const size_t nBHadrons = bHadrons.size();
+  const size_t nCHadrons = cHadrons.size();
+
   Handle<reco::GenJetCollection> src;
   iEvent.getByToken(src_, src);
 
-  auto_ptr<vector<cat::GenJet> >  out(new vector<cat::GenJet>());
+  std::vector<fastjet::PseudoJet> fjInputs;
+  fjInputs.reserve(nBHadrons+nCHadrons+src->size()*100); // nJetx100 from very crude estimation for the size of all jet constituents
+  for ( const reco::GenJet & aGenJet : *src ) {
+    for ( auto& p : aGenJet.getJetConstituents() ) {
+      fjInputs.push_back(fastjet::PseudoJet(p->px(), p->py(), p->pz(), p->energy()));
+      fjInputs.back().set_user_index(fjInputs.size()); // User index for usual particles. This user index is forced to set >=1, to avoid overlap with B hadrons at index=0
+    }
+  }
+  // Do the reclustering including the hadrons
+  for ( auto& ip : bHadrons ) {
+    const auto& p = genParticlesHandle->at(ip);
+    const double p0 = p.p4().P();
+    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
+    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
+    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
+    fjInputs.back().set_user_index(-ip);
+  }
+  for ( auto& ip : cHadrons ) {
+    const auto& p = genParticlesHandle->at(ip);
+    const double p0 = p.p4().P();
+    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
+    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
+    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
+    fjInputs.back().set_user_index(-ip);
+  }
+  // Run the FastJet
+  fastjet::ClusterSequence fjClusterSeq(fjInputs, *fjDef_);
+  std::vector<fastjet::PseudoJet> fjJets = fastjet::sorted_by_pt(fjClusterSeq.inclusive_jets(pt_));
 
-  for (const reco::GenJet & aGenJet : *src) {
+  // Collect heavy flavour jets
+  std::vector<std::vector<int> > jetsToHadrons;
+  for ( auto& jet : fjJets ) {
+    if ( std::abs(jet.eta()) > eta_ ) continue;
+    const auto& fjCons = jet.constituents();
+    std::vector<int> matchedBHadrons, matchedCHadrons;
+    for ( auto& con : fjCons ) {
+      const int index = con.user_index();
+      if ( index >= 1 ) continue; // We are not intestested in the constituents from original jet constituents
+
+      if ( bHadrons.find(index) != bHadrons.end() ) matchedBHadrons.push_back(-index);
+      else if ( cHadrons.find(index) != cHadrons.end() ) matchedCHadrons.push_back(-index);
+    }
+    std::sort(matchedBHadrons.begin(), matchedBHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
+    std::sort(matchedCHadrons.begin(), matchedCHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
+    jetsToHadrons.push_back(matchedBHadrons);
+    jetsToHadrons.back().insert(jetsToHadrons.back().end(), matchedCHadrons.begin(), matchedCHadrons.end());
+  }
+
+  // Start main loop to prepare cat::GenJets
+  for ( size_t i=0, n=src->size(); i<n; ++i ) {
+    const reco::GenJet& aGenJet = src->at(i);
     if ( aGenJet.pt() < pt_ || std::abs(aGenJet.eta()) > eta_ ) continue;
 
     cat::GenJet aCatGenJet(aGenJet);
 
+    // Hadron matching based on particle decay history
     cat::MCParticle matched;
     reco::Jet::Constituents jc = aGenJet.getJetConstituents();
     //if B-Hadron matched, always assign B-Hadron
     for ( reco::Jet::Constituents::const_iterator itr = jc.begin(); itr != jc.end(); ++itr ){
       if (itr->isAvailable()){
-	const reco::Candidate* mcpart = dynamic_cast<const reco::Candidate*>(itr->get());
-	const reco::Candidate* lastB = lastBHadron(*mcpart);
-	if (lastB){
-	  matched = cat::MCParticle(*lastB);
-	  break;
-	}
+        const reco::Candidate* mcpart = dynamic_cast<const reco::Candidate*>(itr->get());
+        const reco::Candidate* lastB = lastBHadron(*mcpart);
+        if (lastB){
+          matched = cat::MCParticle(*lastB);
+          break;
+        }
       }
     }
     if (std::abs(matched.pdgId()) != 5){
       //if only no B-Hadron matched, assign C-Hadron
       for ( reco::Jet::Constituents::const_iterator itr = jc.begin(); itr != jc.end(); ++itr ){
-	if (itr->isAvailable()){
-	  const reco::Candidate* mcpart = dynamic_cast<const reco::Candidate*>(itr->get());
-	  const reco::Candidate* lastC = lastCHadron(*mcpart);
-	  if (lastC){
-	    matched = cat::MCParticle(*lastC);
-	    break;
-	  }
-	}
+        if (itr->isAvailable()){
+          const reco::Candidate* mcpart = dynamic_cast<const reco::Candidate*>(itr->get());
+          const reco::Candidate* lastC = lastCHadron(*mcpart);
+          if (lastC){
+            matched = cat::MCParticle(*lastC);
+            break;
+          }
+        }
       }
     }
+
+    // Another hadron matching based on ghost tagging
+    // Assume that the genJets indices are unchanged by the reclustering
+    cat::MCParticle matchedGhost;
+    const auto& matchedHadrons = jetsToHadrons.at(i);
+    if ( !matchedHadrons.empty() ) matchedGhost = cat::MCParticle(genParticlesHandle->at(matchedHadrons.at(0)));
+
     aCatGenJet.setHadron(matched);
     aCatGenJet.setPdgId(matched.pdgId());
     // int partonFlavour = aGenJet.partonFlavour();
@@ -101,6 +185,8 @@ cat::CATGenJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSe
     // temp - find better way to match flavour and id
     aCatGenJet.setPartonFlavour(matched.pdgId());
     aCatGenJet.setPartonPdgId(matched.pdgId());
+
+    aCatGenJet.setGhost(matchedGhost);
 
     out->push_back(aCatGenJet);
 
@@ -214,6 +300,13 @@ const reco::Candidate* cat::CATGenJetProducer::lastCHadron(const reco::Candidate
   return out;
 }
 
+int cat::CATGenJetProducer::getFlavour(const int pdgId) {
+  const int aid = abs(pdgId);
+  const int code1 = (aid/ 100)%10;
+  const int code2 = (aid/1000)%10;
+
+  return std::max(code1, code2);
+}
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 using namespace cat;

--- a/CatProducer/plugins/CATGenJetProducer.cc
+++ b/CatProducer/plugins/CATGenJetProducer.cc
@@ -6,9 +6,6 @@
 #include "CATTools/DataFormats/interface/GenJet.h"
 #include "CATTools/DataFormats/interface/MCParticle.h"
 
-#include "fastjet/JetDefinition.hh"
-#include "fastjet/ClusterSequence.hh"
-
 using namespace edm;
 using namespace std;
 
@@ -23,10 +20,8 @@ namespace cat {
 
   private:
     edm::EDGetTokenT<reco::GenJetCollection> src_;
-    edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
     const double pt_;
     const double eta_;
-    std::shared_ptr<fastjet::JetDefinition> fjDef_;
 
     std::vector<const reco::Candidate *> getAncestors(const reco::Candidate &c);
     bool hasBottom(const reco::Candidate &c);
@@ -35,7 +30,6 @@ namespace cat {
     bool decayFromCHadron(const reco::Candidate &c);
     const reco::Candidate* lastBHadron(const reco::Candidate &c);
     const reco::Candidate* lastCHadron(const reco::Candidate &c);
-    int getFlavour(const int pdgId);
 
   };
 
@@ -43,108 +37,25 @@ namespace cat {
 
 cat::CATGenJetProducer::CATGenJetProducer(const edm::ParameterSet & iConfig) :
   src_(consumes<reco::GenJetCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-  genParticlesToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
   pt_(iConfig.getParameter<double>("pt")),
-  eta_(iConfig.getParameter<double>("eta")),
-  fjDef_(std::shared_ptr<fastjet::JetDefinition>(new fastjet::JetDefinition(fastjet::antikt_algorithm, 0.4)))
+  eta_(iConfig.getParameter<double>("eta"))
 {
   produces<std::vector<cat::GenJet> >();
 }
 
-void cat::CATGenJetProducer::produce(edm::Event & iEvent, const edm::EventSetup&)
+void
+cat::CATGenJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 {
-  auto_ptr<vector<cat::GenJet> >  out(new vector<cat::GenJet>());
-
-  // Collect heavy-flavour hadrons
-  edm::Handle<reco::GenParticleCollection> genParticlesHandle;
-  iEvent.getByToken(genParticlesToken_, genParticlesHandle);
-  std::set<size_t> bHadrons, cHadrons;
-  for ( size_t i=0, n=genParticlesHandle->size(); i<n; ++i ) {
-    const auto& x = genParticlesHandle->at(i);
-    if ( x.status() == 1 or x.status() == 4 ) continue; // Skip final states and incident beams
-
-    const int aid = abs(x.pdgId());
-    if ( aid < 100 ) continue; // Skip partons
-
-    const int nDau = x.numberOfDaughters();
-    if ( nDau == 0 ) continue; // Skip final states, just for confirmation
-    if ( !x.isLastCopy() ) continue; // Consider the last copy only
-
-    const int flav = getFlavour(aid);
-    if ( flav < 4 ) continue;
-
-    bool isLast = true;
-    for ( int i=0; i<nDau; ++i ) {
-      const int dauFlav = getFlavour(x.daughter(i)->pdgId());
-      if ( flav == dauFlav ) { isLast = false; break; }
-    }
-    if ( !isLast ) continue; // Keep last hadrons only
-
-    if      ( flav == 5 ) bHadrons.insert(i);
-    else if ( flav == 4 ) cHadrons.insert(i);
-  }
-  const size_t nBHadrons = bHadrons.size();
-  const size_t nCHadrons = cHadrons.size();
-
   Handle<reco::GenJetCollection> src;
   iEvent.getByToken(src_, src);
 
-  std::vector<fastjet::PseudoJet> fjInputs;
-  fjInputs.reserve(nBHadrons+nCHadrons+src->size()*100); // nJetx100 from very crude estimation for the size of all jet constituents
-  for ( const reco::GenJet & aGenJet : *src ) {
-    for ( auto& p : aGenJet.getJetConstituents() ) {
-      fjInputs.push_back(fastjet::PseudoJet(p->px(), p->py(), p->pz(), p->energy()));
-      fjInputs.back().set_user_index(fjInputs.size()); // User index for usual particles. This user index is forced to set >=1, to avoid overlap with B hadrons at index=0
-    }
-  }
-  // Do the reclustering including the hadrons
-  for ( auto& ip : bHadrons ) {
-    const auto& p = genParticlesHandle->at(ip);
-    const double p0 = p.p4().P();
-    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
-    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
-    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
-    fjInputs.back().set_user_index(-ip);
-  }
-  for ( auto& ip : cHadrons ) {
-    const auto& p = genParticlesHandle->at(ip);
-    const double p0 = p.p4().P();
-    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
-    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
-    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
-    fjInputs.back().set_user_index(-ip);
-  }
-  // Run the FastJet
-  fastjet::ClusterSequence fjClusterSeq(fjInputs, *fjDef_);
-  std::vector<fastjet::PseudoJet> fjJets = fastjet::sorted_by_pt(fjClusterSeq.inclusive_jets(pt_));
+  auto_ptr<vector<cat::GenJet> >  out(new vector<cat::GenJet>());
 
-  // Collect heavy flavour jets
-  std::vector<std::vector<int> > jetsToHadrons;
-  for ( auto& jet : fjJets ) {
-    if ( std::abs(jet.eta()) > eta_ ) continue;
-    const auto& fjCons = jet.constituents();
-    std::vector<int> matchedBHadrons, matchedCHadrons;
-    for ( auto& con : fjCons ) {
-      const int index = con.user_index();
-      if ( index >= 1 ) continue; // We are not intestested in the constituents from original jet constituents
-
-      if ( bHadrons.find(index) != bHadrons.end() ) matchedBHadrons.push_back(-index);
-      else if ( cHadrons.find(index) != cHadrons.end() ) matchedCHadrons.push_back(-index);
-    }
-    std::sort(matchedBHadrons.begin(), matchedBHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
-    std::sort(matchedCHadrons.begin(), matchedCHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
-    jetsToHadrons.push_back(matchedBHadrons);
-    jetsToHadrons.back().insert(jetsToHadrons.back().end(), matchedCHadrons.begin(), matchedCHadrons.end());
-  }
-
-  // Start main loop to prepare cat::GenJets
-  for ( size_t i=0, n=src->size(); i<n; ++i ) {
-    const reco::GenJet& aGenJet = src->at(i);
+  for (const reco::GenJet & aGenJet : *src) {
     if ( aGenJet.pt() < pt_ || std::abs(aGenJet.eta()) > eta_ ) continue;
 
     cat::GenJet aCatGenJet(aGenJet);
 
-    // Hadron matching based on particle decay history
     cat::MCParticle matched;
     reco::Jet::Constituents jc = aGenJet.getJetConstituents();
     //if B-Hadron matched, always assign B-Hadron
@@ -172,12 +83,6 @@ void cat::CATGenJetProducer::produce(edm::Event & iEvent, const edm::EventSetup&
       }
     }
 
-    // Another hadron matching based on ghost tagging
-    // Assume that the genJets indices are unchanged by the reclustering
-    cat::MCParticle matchedGhost;
-    const auto& matchedHadrons = jetsToHadrons.at(i);
-    if ( !matchedHadrons.empty() ) matchedGhost = cat::MCParticle(genParticlesHandle->at(matchedHadrons.at(0)));
-
     aCatGenJet.setHadron(matched);
     aCatGenJet.setPdgId(matched.pdgId());
     // int partonFlavour = aGenJet.partonFlavour();
@@ -185,8 +90,6 @@ void cat::CATGenJetProducer::produce(edm::Event & iEvent, const edm::EventSetup&
     // temp - find better way to match flavour and id
     aCatGenJet.setPartonFlavour(matched.pdgId());
     aCatGenJet.setPartonPdgId(matched.pdgId());
-
-    aCatGenJet.setGhost(matchedGhost);
 
     out->push_back(aCatGenJet);
 
@@ -298,14 +201,6 @@ const reco::Candidate* cat::CATGenJetProducer::lastCHadron(const reco::Candidate
     }
 
   return out;
-}
-
-int cat::CATGenJetProducer::getFlavour(const int pdgId) {
-  const int aid = abs(pdgId);
-  const int code1 = (aid/ 100)%10;
-  const int code2 = (aid/1000)%10;
-
-  return std::max(code1, code2);
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CatProducer/plugins/GenJetHadronMatchProducer.cc
+++ b/CatProducer/plugins/GenJetHadronMatchProducer.cc
@@ -1,0 +1,173 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CATTools/DataFormats/interface/GenJet.h"
+#include "CATTools/DataFormats/interface/MCParticle.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/ClusterSequence.hh"
+
+using namespace edm;
+using namespace std;
+
+namespace cat {
+
+class GenJetHadronMatchProducer : public edm::stream::EDProducer<>
+{
+public:
+  GenJetHadronMatchProducer(const edm::ParameterSet& pset);
+  virtual ~GenJetHadronMatchProducer() { }
+
+  void produce(edm::Event & event, const edm::EventSetup&) override;
+
+private:
+  int getFlavour(const int pdgId);
+
+private:
+  edm::EDGetTokenT<reco::GenJetCollection> genJetToken_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
+
+  std::shared_ptr<fastjet::JetDefinition> fjDef_;
+
+};
+
+} // namespace
+
+using namespace cat;
+
+GenJetHadronMatchProducer::GenJetHadronMatchProducer(const edm::ParameterSet& pset)
+{
+  genJetToken_ = consumes<reco::GenJetCollection>(pset.getParameter<edm::InputTag>("genJet"));
+  genParticlesToken_ = consumes<reco::GenParticleCollection>(pset.getParameter<edm::InputTag>("genParticle"));
+
+  fjDef_ = std::shared_ptr<fastjet::JetDefinition>(new fastjet::JetDefinition(fastjet::antikt_algorithm, 0.4));
+
+  produces<edm::ValueMap<int> >();
+}
+
+void GenJetHadronMatchProducer::produce(edm::Event& event, const edm::EventSetup&)
+{
+  // Collect heavy-flavour hadrons
+  edm::Handle<reco::GenParticleCollection> genParticlesHandle;
+  event.getByToken(genParticlesToken_, genParticlesHandle);
+  std::set<size_t> bHadrons, cHadrons;
+  for ( size_t i=0, n=genParticlesHandle->size(); i<n; ++i ) {
+    const auto& x = genParticlesHandle->at(i);
+    if ( x.status() == 1 or x.status() == 4 ) continue; // Skip final states and incident beams
+
+    const int aid = abs(x.pdgId());
+    if ( aid < 100 ) continue; // Skip partons
+
+    const int nDau = x.numberOfDaughters();
+    if ( nDau == 0 ) continue; // Skip final states, just for confirmation
+    if ( !x.isLastCopy() ) continue; // Consider the last copy only
+
+    const int flav = getFlavour(aid);
+    if ( flav < 4 ) continue;
+
+    bool isLast = true;
+    for ( int j=0; j<nDau; ++j ) {
+      const int dauFlav = getFlavour(x.daughter(j)->pdgId());
+      if ( flav == dauFlav ) { isLast = false; break; }
+    }
+    if ( !isLast ) continue; // Keep last hadrons only
+
+    if      ( flav == 5 ) bHadrons.insert(i);
+    else if ( flav == 4 ) cHadrons.insert(i);
+  }
+  const size_t nBHadrons = bHadrons.size();
+  const size_t nCHadrons = cHadrons.size();
+
+  edm::Handle<reco::GenJetCollection> genJetHandle;
+  event.getByToken(genJetToken_, genJetHandle);
+
+  std::vector<fastjet::PseudoJet> fjInputs;
+  fjInputs.reserve(nBHadrons+nCHadrons+genJetHandle->size()*100); // nJetx100 from very crude estimation for the size of all jet constituents
+  for ( const reco::GenJet & aGenJet : *genJetHandle ) {
+    for ( auto& p : aGenJet.getJetConstituents() ) {
+      if ( p.isNull() ) continue;
+      fjInputs.push_back(fastjet::PseudoJet(p->px(), p->py(), p->pz(), p->energy()));
+      fjInputs.back().set_user_index(fjInputs.size()); // User index for usual particles. This user index is forced to set >=1, to avoid overlap with B hadrons at index=0
+    }
+  }
+  // Do the reclustering including the hadrons
+  for ( auto& ip : bHadrons ) {
+    const auto& p = genParticlesHandle->at(ip);
+    const double p0 = p.p4().P();
+    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
+    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
+    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
+    fjInputs.back().set_user_index(-ip);
+  }
+  for ( auto& ip : cHadrons ) {
+    const auto& p = genParticlesHandle->at(ip);
+    const double p0 = p.p4().P();
+    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
+    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
+    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
+    fjInputs.back().set_user_index(-ip);
+  }
+
+  // Run the FastJet
+  fastjet::ClusterSequence fjClusterSeq(fjInputs, *fjDef_);
+  std::vector<fastjet::PseudoJet> fjJets = fastjet::sorted_by_pt(fjClusterSeq.inclusive_jets(5.0));
+
+  // Collect heavy flavour jets
+  std::map<int, int> jetToFlav;
+  //std::vector<std::vector<int> > jetsToHadrons;
+  for ( size_t i=0, n=fjJets.size(); i<n; ++i ) {
+    const auto& jet = fjJets.at(i);
+    const auto& fjCons = jet.constituents();
+    //std::vector<int> matchedBHadrons, matchedCHadrons;
+
+    int flav = 0;
+    for ( auto& con : fjCons ) {
+      const int index = con.user_index();
+      if ( index >= 1 ) continue; // We are not intestested in the constituents from original jet constituents
+
+      //if      ( bHadrons.find(index) != bHadrons.end() ) matchedBHadrons.push_back(-index);
+      //else if ( cHadrons.find(index) != cHadrons.end() ) matchedCHadrons.push_back(-index);
+      if      ( bHadrons.find(-index) != bHadrons.end() ) flav = 5;
+      else if ( cHadrons.find(-index) != cHadrons.end() ) flav = 4;
+    }
+
+    jetToFlav[i] = flav;
+    //std::sort(matchedBHadrons.begin(), matchedBHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
+    //std::sort(matchedCHadrons.begin(), matchedCHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
+    //jetsToHadrons.push_back(matchedBHadrons);
+    //jetsToHadrons.back().insert(jetsToHadrons.back().end(), matchedCHadrons.begin(), matchedCHadrons.end());
+  }
+
+  // Start main loop to prepare GenJets
+  std::auto_ptr<edm::ValueMap<int> > out(new edm::ValueMap<int>);
+  std::vector<int> flavours;
+  flavours.reserve(genJetHandle->size());
+  for ( size_t i=0, n=genJetHandle->size(); i<n; ++i ) {
+    //const reco::GenJet& genJet = genJetHandle->at(i);
+    // Assume that the genJets indices are unchanged by the reclustering
+    int flav = 0;
+    if ( jetToFlav.find(i) != jetToFlav.end() ) flav = jetToFlav[i];
+
+    flavours.push_back(flav);
+  }
+  edm::ValueMap<int>::Filler outFiller(*out);
+  outFiller.insert(genJetHandle, flavours.begin(), flavours.end());
+  outFiller.fill();
+  event.put(out);
+
+}
+
+int GenJetHadronMatchProducer::getFlavour(const int pdgId) {
+  const int aid = abs(pdgId);
+  const int code1 = (aid/ 100)%10;
+  const int code2 = (aid/1000)%10;
+
+  return std::max(code1, code2);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace cat;
+DEFINE_FWK_MODULE(GenJetHadronMatchProducer);

--- a/CatProducer/plugins/GenJetHadronMatchProducer.cc
+++ b/CatProducer/plugins/GenJetHadronMatchProducer.cc
@@ -5,10 +5,9 @@
 
 #include "CATTools/DataFormats/interface/GenJet.h"
 #include "CATTools/DataFormats/interface/MCParticle.h"
-#include "DataFormats/Common/interface/ValueMap.h"
 
-#include "fastjet/JetDefinition.hh"
-#include "fastjet/ClusterSequence.hh"
+#include "SimDataFormats/JetMatching/interface/JetFlavourInfo.h"
+#include "SimDataFormats/JetMatching/interface/JetFlavourInfoMatching.h"
 
 using namespace edm;
 using namespace std;
@@ -24,13 +23,11 @@ public:
   void produce(edm::Event & event, const edm::EventSetup&) override;
 
 private:
-  int getFlavour(const int pdgId);
+  void collectAncestorPartons(const reco::Candidate* cand, std::set<int>& partonIds) const;
 
-private:
+  //edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
   edm::EDGetTokenT<reco::GenJetCollection> genJetToken_;
-  edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
-
-  std::shared_ptr<fastjet::JetDefinition> fjDef_;
+  edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> genJetFlavourToken_;
 
 };
 
@@ -38,134 +35,82 @@ private:
 
 using namespace cat;
 
+typedef std::vector<int> vint;
+typedef std::vector<vint> vvint;
+
 GenJetHadronMatchProducer::GenJetHadronMatchProducer(const edm::ParameterSet& pset)
 {
+  //genParticlesToken_ = consumes<reco::GenParticleCollection>(pset.getParameter<edm::InputTag>("genParticle"));
   genJetToken_ = consumes<reco::GenJetCollection>(pset.getParameter<edm::InputTag>("genJet"));
-  genParticlesToken_ = consumes<reco::GenParticleCollection>(pset.getParameter<edm::InputTag>("genParticle"));
+  genJetFlavourToken_ = consumes<reco::JetFlavourInfoMatchingCollection>(pset.getParameter<edm::InputTag>("genJetFlavour"));
 
-  fjDef_ = std::shared_ptr<fastjet::JetDefinition>(new fastjet::JetDefinition(fastjet::antikt_algorithm, 0.4));
-
-  produces<edm::ValueMap<int> >();
+  produces<vint>("flavour");
+  produces<vvint>("ancestorIds");
 }
 
 void GenJetHadronMatchProducer::produce(edm::Event& event, const edm::EventSetup&)
 {
-  // Collect heavy-flavour hadrons
-  edm::Handle<reco::GenParticleCollection> genParticlesHandle;
-  event.getByToken(genParticlesToken_, genParticlesHandle);
-  std::set<size_t> bHadrons, cHadrons;
-  for ( size_t i=0, n=genParticlesHandle->size(); i<n; ++i ) {
-    const auto& x = genParticlesHandle->at(i);
-    if ( x.status() == 1 or x.status() == 4 ) continue; // Skip final states and incident beams
-
-    const int aid = abs(x.pdgId());
-    if ( aid < 100 ) continue; // Skip partons
-
-    const int nDau = x.numberOfDaughters();
-    if ( nDau == 0 ) continue; // Skip final states, just for confirmation
-    if ( !x.isLastCopy() ) continue; // Consider the last copy only
-
-    const int flav = getFlavour(aid);
-    if ( flav < 4 ) continue;
-
-    bool isLast = true;
-    for ( int j=0; j<nDau; ++j ) {
-      const int dauFlav = getFlavour(x.daughter(j)->pdgId());
-      if ( flav == dauFlav ) { isLast = false; break; }
-    }
-    if ( !isLast ) continue; // Keep last hadrons only
-
-    if      ( flav == 5 ) bHadrons.insert(i);
-    else if ( flav == 4 ) cHadrons.insert(i);
-  }
-  const size_t nBHadrons = bHadrons.size();
-  const size_t nCHadrons = cHadrons.size();
-
   edm::Handle<reco::GenJetCollection> genJetHandle;
   event.getByToken(genJetToken_, genJetHandle);
 
-  std::vector<fastjet::PseudoJet> fjInputs;
-  fjInputs.reserve(nBHadrons+nCHadrons+genJetHandle->size()*100); // nJetx100 from very crude estimation for the size of all jet constituents
-  for ( const reco::GenJet & aGenJet : *genJetHandle ) {
-    for ( auto& p : aGenJet.getJetConstituents() ) {
-      if ( p.isNull() ) continue;
-      fjInputs.push_back(fastjet::PseudoJet(p->px(), p->py(), p->pz(), p->energy()));
-      fjInputs.back().set_user_index(fjInputs.size()); // User index for usual particles. This user index is forced to set >=1, to avoid overlap with B hadrons at index=0
-    }
-  }
-  // Do the reclustering including the hadrons
-  for ( auto& ip : bHadrons ) {
-    const auto& p = genParticlesHandle->at(ip);
-    const double p0 = p.p4().P();
-    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
-    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
-    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
-    fjInputs.back().set_user_index(-ip);
-  }
-  for ( auto& ip : cHadrons ) {
-    const auto& p = genParticlesHandle->at(ip);
-    const double p0 = p.p4().P();
-    const double fP = 1E-7/p0; // Rescale to negligible factor, hadron will have 1e-7 GeV in momentum
-    const double e = std::hypot(p.mass(), p0*fP); // re-calculate energy to reserve particle mass
-    fjInputs.push_back(fastjet::PseudoJet(p.px()*fP, p.py()*fP, p.pz()*fP, e));
-    fjInputs.back().set_user_index(-ip);
-  }
+  edm::Handle<reco::JetFlavourInfoMatchingCollection> genJetFlavourHandle;
+  event.getByToken(genJetFlavourToken_, genJetFlavourHandle);
 
-  // Run the FastJet
-  fastjet::ClusterSequence fjClusterSeq(fjInputs, *fjDef_);
-  std::vector<fastjet::PseudoJet> fjJets = fastjet::sorted_by_pt(fjClusterSeq.inclusive_jets(5.0));
+  // Collect HF, LF jets
+  std::map<int, int> jetToFlavour;
+  std::map<int, std::vector<int> > jetToPartonIds;
+  for ( auto& jetFlavPair : *genJetFlavourHandle ) {
+    const auto& jetRefBase = jetFlavPair.first;
+    const auto& flavInfo = jetFlavPair.second;
+    const int jetIndex = jetRefBase.key();
 
-  // Collect heavy flavour jets
-  std::map<int, int> jetToFlav;
-  //std::vector<std::vector<int> > jetsToHadrons;
-  for ( size_t i=0, n=fjJets.size(); i<n; ++i ) {
-    const auto& jet = fjJets.at(i);
-    const auto& fjCons = jet.constituents();
-    //std::vector<int> matchedBHadrons, matchedCHadrons;
+    const auto& bHadrons = flavInfo.getbHadrons();
+    const auto& cHadrons = flavInfo.getcHadrons();
+    //const auto& partons = flavInfo.getPartons();
 
-    int flav = 0;
-    for ( auto& con : fjCons ) {
-      const int index = con.user_index();
-      if ( index >= 1 ) continue; // We are not intestested in the constituents from original jet constituents
+    if      ( !bHadrons.empty() ) jetToFlavour[jetIndex] = 5;
+    else if ( !cHadrons.empty() ) jetToFlavour[jetIndex] = 4;
+    else jetToFlavour[jetIndex] = 0;
 
-      //if      ( bHadrons.find(index) != bHadrons.end() ) matchedBHadrons.push_back(-index);
-      //else if ( cHadrons.find(index) != cHadrons.end() ) matchedCHadrons.push_back(-index);
-      if      ( bHadrons.find(-index) != bHadrons.end() ) flav = 5;
-      else if ( cHadrons.find(-index) != cHadrons.end() ) flav = 4;
+    std::set<int> partonIds;
+    for ( auto& x : jetRefBase->getJetConstituents() ) {
+      if ( x.isNull() ) continue;
+      collectAncestorPartons(x.get(), partonIds);
     }
 
-    jetToFlav[i] = flav;
-    //std::sort(matchedBHadrons.begin(), matchedBHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
-    //std::sort(matchedCHadrons.begin(), matchedCHadrons.end(), [&](int a, int b){return genParticlesHandle->at(a).pt() > genParticlesHandle->at(b).pt();});
-    //jetsToHadrons.push_back(matchedBHadrons);
-    //jetsToHadrons.back().insert(jetsToHadrons.back().end(), matchedCHadrons.begin(), matchedCHadrons.end());
+    jetToPartonIds.insert(std::make_pair(jetIndex, std::vector<int>()));
+    auto& vPartonIds = jetToPartonIds[jetIndex];
+    vPartonIds.reserve(partonIds.size());
+    std::copy(partonIds.begin(), partonIds.end(), std::back_inserter(vPartonIds));
   }
 
-  // Start main loop to prepare GenJets
-  std::auto_ptr<edm::ValueMap<int> > out(new edm::ValueMap<int>);
-  std::vector<int> flavours;
-  flavours.reserve(genJetHandle->size());
-  for ( size_t i=0, n=genJetHandle->size(); i<n; ++i ) {
-    //const reco::GenJet& genJet = genJetHandle->at(i);
-    // Assume that the genJets indices are unchanged by the reclustering
-    int flav = 0;
-    if ( jetToFlav.find(i) != jetToFlav.end() ) flav = jetToFlav[i];
+  std::auto_ptr<vint> out_flavours(new vint);
+  std::auto_ptr<vvint> out_ancestorIds(new vvint);
+  for ( int i=0, n=genJetHandle->size(); i<n; ++i ) {
+    auto fitr = jetToFlavour.find(i);
+    if ( fitr == jetToFlavour.end() ) out_flavours->push_back(0);
+    else out_flavours->push_back(fitr->second);
 
-    flavours.push_back(flav);
+    auto itr = jetToPartonIds.find(i);
+    if ( itr == jetToPartonIds.end() ) out_ancestorIds->push_back(vint());
+    else out_ancestorIds->push_back(itr->second);
   }
-  edm::ValueMap<int>::Filler outFiller(*out);
-  outFiller.insert(genJetHandle, flavours.begin(), flavours.end());
-  outFiller.fill();
-  event.put(out);
+  event.put(out_flavours, "flavour");
+  event.put(out_ancestorIds, "ancestorIds");
 
 }
 
-int GenJetHadronMatchProducer::getFlavour(const int pdgId) {
-  const int aid = abs(pdgId);
-  const int code1 = (aid/ 100)%10;
-  const int code2 = (aid/1000)%10;
+void GenJetHadronMatchProducer::collectAncestorPartons(const reco::Candidate* cand, std::set<int>& partonIds) const {
+  if ( !cand ) return;
 
-  return std::max(code1, code2);
+  for ( int i=0, n=cand->numberOfMothers(); i<n; ++i ) {
+    const reco::Candidate* p = cand->mother(i);
+    if ( !p or p->status() == 4 ) continue;
+    const int aid = abs(p->pdgId());
+    if ( aid == 6 or aid == 24 or aid == 23 or aid == 25 ) partonIds.insert(p->pdgId());
+
+    collectAncestorPartons(p, partonIds);
+  }
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CatProducer/python/catCandidates_cff.py
+++ b/CatProducer/python/catCandidates_cff.py
@@ -11,3 +11,4 @@ from CATTools.CatProducer.dstarProducer_cfi import *
 from CATTools.CatProducer.vertexProducer_cfi import *
 from CATTools.CatProducer.triggerProducer_cfi import *
 from CATTools.CatProducer.genTopProducer_cfi import * #please do not remove it.
+from CATTools.CatProducer.genJetHadronMatch_cfi import *

--- a/CatProducer/python/catEventContent_cff.py
+++ b/CatProducer/python/catEventContent_cff.py
@@ -43,6 +43,7 @@ catEventContentTOPMC.extend([
     'keep *_catGenTops_*_*',
     'keep *_partonTop_*_*',
     'keep *_pseudoTop_*_*',
+    'keep *_genJetHadronFlavour_*_*',
     ])
 
 catEventContentSecVertexs.extend([

--- a/CatProducer/python/genJetHadronMatch_cfi.py
+++ b/CatProducer/python/genJetHadronMatch_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+genJetHadronFlavour = cms.EDProducer("GenJetHadronMatchProducer",
+    genJet = cms.InputTag("slimmedGenJets"),
+    genParticle = cms.InputTag("prunedGenParticles"),
+)

--- a/CatProducer/python/genJetHadronMatch_cfi.py
+++ b/CatProducer/python/genJetHadronMatch_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 genJetHadronFlavour = cms.EDProducer("GenJetHadronMatchProducer",
     genJet = cms.InputTag("slimmedGenJets"),
-    genParticle = cms.InputTag("prunedGenParticles"),
+    genJetFlavour = cms.InputTag("genJetFlavourInfos"),
 )

--- a/DataFormats/interface/GenJet.h
+++ b/DataFormats/interface/GenJet.h
@@ -29,19 +29,16 @@ namespace cat {
 
     const MCParticle hadron() const {return hadron_; }
     void setHadron( MCParticle Had ) { hadron_ = Had; }	
-    void setGhost(MCParticle ghost) { ghost_ = ghost; }
     /// \return the matched MC parton flavour (from the shower, used e.g. for b-tagging)
     int partonFlavour() const{ return partonFlavour_;}
     /// \return the pdgId of the matched MC parton from hard scattering (i.e. the closest quark or gluon of status == 3)
     int partonPdgId() const{ return partonPdgId_;}
-    int ghostFlavour() const { return ghost_.pdgId(); }
     void setPartonFlavour(int i) { partonFlavour_ = i; }
     void setPartonPdgId(int i) { partonPdgId_ = i; }
 
   private:
 
     MCParticle hadron_;
-    MCParticle ghost_;
     //parton flavour
     int partonFlavour_;
     int partonPdgId_;

--- a/DataFormats/interface/GenJet.h
+++ b/DataFormats/interface/GenJet.h
@@ -29,16 +29,19 @@ namespace cat {
 
     const MCParticle hadron() const {return hadron_; }
     void setHadron( MCParticle Had ) { hadron_ = Had; }	
+    void setGhost(MCParticle ghost) { ghost_ = ghost; }
     /// \return the matched MC parton flavour (from the shower, used e.g. for b-tagging)
     int partonFlavour() const{ return partonFlavour_;}
     /// \return the pdgId of the matched MC parton from hard scattering (i.e. the closest quark or gluon of status == 3)
     int partonPdgId() const{ return partonPdgId_;}
+    int ghostFlavour() const { return ghost_.pdgId(); }
     void setPartonFlavour(int i) { partonFlavour_ = i; }
     void setPartonPdgId(int i) { partonPdgId_ = i; }
 
   private:
 
     MCParticle hadron_;
+    MCParticle ghost_;
     //parton flavour
     int partonFlavour_;
     int partonPdgId_;


### PR DESCRIPTION
Per-genJet hadron matching information is stored in the output.
Also, the list of parton's pdg ids are stored to do the parton-genJet matching, just keeping pdgIds of interested partons (top, W,Z H).

The output size is expected to be small.

```
Type                                  Module                   Label             Process   
-------------------------------------------------------------------------------------------
vector<int>                           "genJetHadronFlavour"    "flavour"         "CAT"     
vector<vector<int> >                  "genJetHadronFlavour"    "ancestorIds"     "CAT"     
```

```
Branch Name | Average Uncompressed Size (Bytes/Event) | Average Compressed Size (Bytes/Event) 
intss_genJetHadronFlavour_ancestorIds_CAT. 122.29 36.83
ints_genJetHadronFlavour_flavour_CAT. 73.63 30.53
```

@YoungKwonJo please check this is what you wanted.
