### PR TITLE
Smearing only if exact solution is missing

### DIFF
--- a/CatAnalyzer/interface/KinematicSolvers.h
+++ b/CatAnalyzer/interface/KinematicSolvers.h
@@ -109,6 +109,7 @@ protected:
 
   const int nTrial_;
   const double maxLBMass_, mTopInput_;
+  const bool weightByMnub_;
 };
 
 // Neutrino weighting method (from thesis by Temple)

--- a/CatAnalyzer/python/ttll/ttbarDileptonKinSolutionAlgos_cff.py
+++ b/CatAnalyzer/python/ttll/ttbarDileptonKinSolutionAlgos_cff.py
@@ -29,6 +29,7 @@ ttbarDileptonKinAlgoPSetDESYSmeared = cms.PSet(
     nTrial = cms.int32(100),
     maxLBMass = cms.double(360),
     mTopInput = cms.double(172.5),
+    weightByMnub = cms.bool(False),
 )
 
 ttbarDileptonKinAlgoPSetDESYMassLoop = cms.PSet(

--- a/CatAnalyzer/src/KinematicSolvers.cc
+++ b/CatAnalyzer/src/KinematicSolvers.cc
@@ -354,6 +354,7 @@ void DESYSmearedSolver::solve(const LV input[])
     }
     if ( maxWeightSol > 0 ) {
       if ( weightByMnub_ ) weight *= maxWeightSol;
+      else weight = sqrt(weight);
       l1_ = l1; l2_ = l2; j1_ = j1; j2_ = j2;
       nu1_.SetXYZT(nu1sol[0], nu1sol[1], nu1sol[2], nu1sol[3]);
       nu2_.SetXYZT(nu2sol[0], nu2sol[1], nu2sol[2], nu2sol[3]);
@@ -437,6 +438,7 @@ void DESYSmearedSolver::solve(const LV input[])
     if ( maxWeightSol <= 0 ) continue;
 
     if ( weightByMnub_ ) weight *= maxWeightSol;
+    else weight = sqrt(weight);
     sumW += weight;
     sumP[0][0] += weight*newl1.px(); sumP[0][1] += weight*newl1.py(); sumP[0][2] += weight*newl1.pz();
     sumP[1][0] += weight*newl2.px(); sumP[1][1] += weight*newl2.py(); sumP[1][2] += weight*newl2.pz();


### PR DESCRIPTION
Take the solution without smearing if it exact solution exists - this gives better resolution.
- Top quark (pt_kin - pt_truth)/(pt_truth)
  ![htdpt](https://cloud.githubusercontent.com/assets/4388926/13550493/3768ffe4-e31f-11e5-922d-fba0bccef7d4.png)
- Top quark (eta_kin - eta_truth)
  ![htdeta](https://cloud.githubusercontent.com/assets/4388926/13550500/51c807d6-e31f-11e5-92de-2fd7faed08fe.png)
- Top quark (phi_kin - phi_truth)
  ![htdphi](https://cloud.githubusercontent.com/assets/4388926/13550501/61df517e-e31f-11e5-9e9e-5bff73816eb0.png)

This is to be merged after confirmation.
