### PR TITLE
Use XYZTLorentzVector for compatibility

### DIFF
--- a/CatAnalyzer/interface/KinematicReconstruction.h
+++ b/CatAnalyzer/interface/KinematicReconstruction.h
@@ -17,9 +17,6 @@ class KinematicReconstructionSolutions;
 class KinematicReconstruction_MeanSol;
 
 
-
-
-
 struct Struct_KinematicReconstruction{
     TLorentzVector lp, lm;
     TLorentzVector jetB, jetBbar;
@@ -33,10 +30,6 @@ struct Struct_KinematicReconstruction{
     double weight;
     int ntags;
 };
-
-
-
-
 
 class KinematicReconstruction{
     
@@ -121,11 +114,6 @@ private:
 // mbl
     TH1* h_mbl_w_;
 };
-
-
-
-
-
 
 
 class KinematicReconstructionScaleFactors{

--- a/CatAnalyzer/interface/analysisUtils.h
+++ b/CatAnalyzer/interface/analysisUtils.h
@@ -23,11 +23,11 @@ namespace common{
     std::string d2s(const double& d);
     
     
-    /// Conversion from TLorentzVector to our LV type (ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >)
+    /// Conversion from TLorentzVector to our LV type
     const LV TLVtoLV(const TLorentzVector& lv);
     
     
-    /// Conversion from our LV type to TLorentzVector (ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> >)
+    /// Conversion from our LV type to TLorentzVector
     const TLorentzVector LVtoTLV(const LV& lv);
 }
 

--- a/CatAnalyzer/interface/classes.h
+++ b/CatAnalyzer/interface/classes.h
@@ -4,16 +4,12 @@
 #include "classesFwd.h"
 
 #include <Math/LorentzVector.h>
-#include <Math/PtEtaPhiM4D.h>
-
-
+#include <Math/PxPyPzE4D.h>
 
 namespace {
     LV dummy;
     VLV dummy2;
 }
-
-
 
 #endif
 

--- a/CatAnalyzer/interface/classesFwd.h
+++ b/CatAnalyzer/interface/classesFwd.h
@@ -3,21 +3,17 @@
 
 #include <vector>
 
-
-
-
-
 // For LorentzVector - ROOT dictionary
 
 namespace ROOT{
     namespace Math{
-        template<typename T> class PtEtaPhiM4D;
+        template<typename T> class PxPyPzE4D;
         template<class T> class LorentzVector;
     }
 }
 
 /// Our Lorentz vector as used in the nTuple
-typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > LV;
+typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > LV;
 
 /// Vector of our Lorentz vector as used in the nTuple
 typedef std::vector<LV> VLV;

--- a/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
+++ b/CatAnalyzer/plugins/ColorCoherenceAnalyzer.cc
@@ -20,7 +20,6 @@
 
 #include "TTree.h"
 #include "TLorentzVector.h"
-#include "Math/PtEtaPhiM4D.h"
 #include "TRandom.h"
 
 #define _USE_MATH_DEFINES

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -159,7 +159,7 @@ private:
   std::unique_ptr<KinematicSolver> solver_;
 
   const KinematicReconstruction* kinematicReconstruction;
-  typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > LV;
+  typedef math::XYZTLorentzVector LV;
   typedef std::vector<LV> VLV;
 
   const static int NCutflow = 10;
@@ -790,11 +790,11 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
       vector<int> leptonIndex, antiLeptonIndex, jetIndices, bjetIndices;
       VLV allLeptonslv, jetslv;
       vector<double> jetBtags;
-      LV metlv = common::TLVtoLV(mets->front().tlv());
+      LV metlv = mets->front().p4();
 
       int ijet=0;
       for (auto & jet : selectedJets){
-	jetslv.push_back(common::TLVtoLV(jet.tlv()));
+	jetslv.push_back(jet.p4());
 	jetBtags.push_back(jet.bDiscriminator(BTAG_CSVv2));
 	if (jet.bDiscriminator(BTAG_CSVv2) < WP_BTAG_CSVv2L) jetIndices.push_back(ijet);
 	else bjetIndices.push_back(ijet);
@@ -803,7 +803,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
       
       int ilep = 0;
       for (auto & lep : recolep){
-	allLeptonslv.push_back(common::TLVtoLV(lep->tlv()));
+	allLeptonslv.push_back(lep->p4());
 	if (lep->charge() > 0) antiLeptonIndex.push_back(ilep);
 	else leptonIndex.push_back(ilep);
 	++ilep;

--- a/CatAnalyzer/src/KinematicReconstruction.cc
+++ b/CatAnalyzer/src/KinematicReconstruction.cc
@@ -20,22 +20,7 @@
 #include "CATTools/CatAnalyzer/interface/KinematicReconstruction_MeanSol.h"
 #include "CATTools/CatAnalyzer/interface/KinematicReconstructionSolution.h"
 
-
-
-
 constexpr double TopMASS = 172.5;
-
-
-
-
-
-
-
-
-
-
-
-
 
 // -------------------------------------- Methods for KinematicReconstruction --------------------------------------
 
@@ -145,7 +130,6 @@ void KinematicReconstruction::setRandomNumberSeeds(const LV& lepton, const LV& a
     gRandom->SetSeed(seed);
     r3_->SetSeed(seed);
 }
-
 
 
 KinematicReconstructionSolutions KinematicReconstruction::solutions(const std::vector<int>& leptonIndices, const std::vector<int>& antiLeptonIndices,


### PR DESCRIPTION
DESY kinsolver extensively uses PtEtaPhiM interpretation to return the results, but math::XYZTLorentzVector is the standard format to store lorentzVector.

Migrating to use the PxPyPzE reduces un-necessary conversions between them.
There should no physics change up to numerical precision (in fact, this migration reduces numerical error propagation).
