### PR TITLE
KinSolver bugfix + Priority to solution with b tagged jet

### DIFF
--- a/CatAnalyzer/interface/KinematicSolvers.h
+++ b/CatAnalyzer/interface/KinematicSolvers.h
@@ -67,6 +67,11 @@ class KinematicSolver
 public:
   KinematicSolver(const edm::ParameterSet& pset) {}
   virtual ~KinematicSolver() {}
+  void solve(const LV met, const LV l1, const LV l2, const LV j1, const LV j2)
+  {
+    LV input[5] = {met, l1, l2, j1, j2};
+    solve(input);
+  }
   virtual void solve(const LV input[]) = 0;
   virtual std::string algoName() = 0;
 

--- a/CatAnalyzer/interface/KinematicSolvers.h
+++ b/CatAnalyzer/interface/KinematicSolvers.h
@@ -33,7 +33,20 @@ struct KinematicSolution
   const LV t1() const { return t1_; }
   const LV t2() const { return t2_; }
 
-  friend class KinematicSolver;
+  void setVisible(const LV& l1, const LV& l2, const LV& j1, const LV& j2) {
+    l1_ = l1; l2_ = l2; j1_ = j1; j2_ = j2;
+  }
+
+  void setSolution(const double quality, const LV& nu1, const LV& nu2,
+                   const std::vector<double> values = {}) {
+    quality_ = quality;
+    values_ = values;
+
+    nu1_ = nu1; nu2_ = nu2;
+
+    t1_ = l1_+j1_+nu1_;
+    t2_ = l2_+j2_+nu2_;
+  }
 
   double quality_;
   LV l1_, l2_, j1_, j2_;

--- a/CatAnalyzer/interface/KinematicSolvers.h
+++ b/CatAnalyzer/interface/KinematicSolvers.h
@@ -18,6 +18,8 @@ class KinematicSolver;
 
 struct KinematicSolution
 {
+  KinematicSolution() { quality_ = -1e9; }
+
   double quality() const { return quality_; }
   const LV l1() const { return l1_; }
   const LV l2() const { return l2_; }
@@ -33,12 +35,16 @@ struct KinematicSolution
   const LV t1() const { return t1_; }
   const LV t2() const { return t2_; }
 
-  void setVisible(const LV& l1, const LV& l2, const LV& j1, const LV& j2) {
+  void setVisible(const LV& l1, const LV& l2, const LV& j1, const LV& j2)
+  {
+    quality_ = -1e9;
+    values_.clear();
     l1_ = l1; l2_ = l2; j1_ = j1; j2_ = j2;
   }
 
   void setSolution(const double quality, const LV& nu1, const LV& nu2,
-                   const std::vector<double> values = {}) {
+                   const std::vector<double> values = {})
+  {
     quality_ = quality;
     values_ = values;
 

--- a/CatAnalyzer/interface/KinematicSolvers.h
+++ b/CatAnalyzer/interface/KinematicSolvers.h
@@ -14,15 +14,10 @@ class TtFullLepKinSolver;
 namespace cat {
 
 typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > LV;
+class KinematicSolver;
 
-class KinematicSolver
+struct KinematicSolution
 {
-public:
-  KinematicSolver(const edm::ParameterSet& pset) {}
-  virtual ~KinematicSolver() {}
-  virtual void solve(const LV input[]) = 0;
-  virtual std::string algoName() = 0;
-
   double quality() const { return quality_; }
   const LV l1() const { return l1_; }
   const LV l2() const { return l2_; }
@@ -32,18 +27,49 @@ public:
   const LV nu2() const { return nu2_; }
   double aux(size_t i) const { return values_.at(i); }
   const std::vector<double>& aux() const { return values_; }
-
   const LV w1() const { return l1()+nu1(); }
   const LV w2() const { return l2()+nu2(); }
-  virtual const LV t1() const { return w1()+j1(); } // Virtual since the smeared solver have to fix the top quark mass
-  virtual const LV t2() const { return w2()+j2(); } // Virtual since the smeared solver have to fix the top quark mass
   const LV tt() const { return t1()+t2(); }
+  const LV t1() const { return t1_; }
+  const LV t2() const { return t2_; }
+
+  friend class KinematicSolver;
+
+  double quality_;
+  LV l1_, l2_, j1_, j2_;
+  LV nu1_, nu2_;
+  LV t1_, t2_;
+  std::vector<double> values_;
+
+};
+
+class KinematicSolver
+{
+public:
+  KinematicSolver(const edm::ParameterSet& pset) {}
+  virtual ~KinematicSolver() {}
+  virtual void solve(const LV input[]) = 0;
+  virtual std::string algoName() = 0;
+
+  KinematicSolution solution() const { return sol_; }
+  // Legacy interfaces
+  double quality() const { return sol_.quality_; }
+  const LV l1() const { return sol_.l1_; }
+  const LV l2() const { return sol_.l2_; }
+  const LV j1() const { return sol_.j1_; }
+  const LV j2() const { return sol_.j2_; }
+  const LV nu1() const { return sol_.nu1_; }
+  const LV nu2() const { return sol_.nu2_; }
+  double aux(size_t i) const { return sol_.values_.at(i); }
+  const std::vector<double>& aux() const { return sol_.values_; }
+  const LV w1() const { return l1()+nu1(); }
+  const LV w2() const { return l2()+nu2(); }
+  const LV tt() const { return t1()+t2(); }
+  const LV t1() const { return sol_.t1_; }
+  const LV t2() const { return sol_.t2_; }
 
 protected:
-  double quality_;
-  LV nu1_, nu2_;
-  LV l1_, l2_, j1_, j2_;
-  std::vector<double> values_;
+  KinematicSolution sol_;
 };
 
 class TTDileptonSolver : public KinematicSolver // A dummy solver for now
@@ -103,9 +129,6 @@ public:
   std::string algoName() override { return "DESYSmeared"; }
   void setRandom(CLHEP::HepRandomEngine* rng) { rng_ = rng; }
 
-  LV t1() { return t1_; }
-  LV t2() { return t2_; }
-
 protected:
   LV getSmearedLV(const LV& v, const double fE, const double dRot);
   double getRandom(TH1* h);
@@ -118,8 +141,6 @@ protected:
 
   const int nTrial_;
   const double maxLBMass_, mTopInput_;
-
-  LV t1_, t2_;
 };
 
 }

--- a/CatAnalyzer/interface/TopKinSolverUtils.h
+++ b/CatAnalyzer/interface/TopKinSolverUtils.h
@@ -14,7 +14,7 @@ struct KinSolverUtils {
   //class TtFullLepSolution;
   typedef ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double> > LV;
 
-  static inline bool isZero(const double x) { return std::abs(x) < 1e-5; };
+  static inline bool isZero(const double x) { return std::abs(x) < 1e-13; };
   //void print(const std::vector<TtFullLepSolution>& sols);
   static void findCoeffs(const double mT, const double mW1, const double mW2,
                          const LV& l1, const LV& l2, const LV& b1, const LV& b2,

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -896,8 +896,8 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     math::XYZTLorentzVector top1, top2, nu1, nu2, bjet1, bjet2;
     // Prefer to select b jets
     cat::KinematicSolution sol;
-    if      ( !sol2Bs.empty() ) sol = *sol2Bs.begin();
-    else if ( !sol1Bs.empty() ) sol = *sol1Bs.begin();
+    if      ( !sol2Bs.empty() ) sol = sol2Bs.front();
+    else if ( !sol1Bs.empty() ) sol = sol1Bs.front();
     //else if ( !sol0Bs.empty() ) sol = sol0Bs.front();
 
     //saving results

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -898,7 +898,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     cat::KinematicSolution sol;
     if      ( !sol2Bs.empty() ) sol = sol2Bs.front();
     else if ( !sol1Bs.empty() ) sol = sol1Bs.front();
-    else if ( !sol0Bs.empty() ) sol = sol0Bs.front();
+    //else if ( !sol0Bs.empty() ) sol = sol0Bs.front();
 
     //saving results
     const double maxweight = sol.quality();

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -72,7 +72,7 @@ private:
     return 1;
   }
   float getElEffSF(const cat::Lepton& p, int sys) const
-  { 
+  {
     const int aid = abs(p.pdgId());
     if ( aid == 11 ) {
       const auto& el = dynamic_cast<const cat::Electron&>(p);
@@ -243,8 +243,8 @@ TtbarDiLeptonAnalyzer::TtbarDiLeptonAnalyzer(const edm::ParameterSet& iConfig)
     //    "mueff_u", "mueff_d", "eleff_u", "eleff_d",
     //    "btag_u", "btag_d"
   };
-  
-  h_nevents = fs->make<TH1D>("nevents","nevents",1,0,1);       
+
+  h_nevents = fs->make<TH1D>("nevents","nevents",1,0,1);
   for (int sys = 0; sys < nsys_e; ++sys){
     ttree_.push_back(fs->make<TTree>(sys_name[sys].c_str(), sys_name[sys].c_str()));
     auto tr = ttree_.back();
@@ -389,10 +389,10 @@ TtbarDiLeptonAnalyzer::TtbarDiLeptonAnalyzer(const edm::ParameterSet& iConfig)
     tr->Branch("desyttbar_dphi", &b_desyttbar_dphi, "desyttbar_dphi/F");
     tr->Branch("desyttbar_rapi", &b_desyttbar_rapi, "desyttbar_rapi/F");
     tr->Branch("desyttbar_m", &b_desyttbar_m, "desyttbar_m/F");
-    
+
     tr->Branch("is3lep", &b_is3lep, "is3lep/I");
   }
- 
+
   for (int i = 0; i < NCutflow; i++) cutflow_.push_back({0,0,0,0});
 
   kinematicReconstruction = new KinematicReconstruction(1, true);
@@ -651,10 +651,9 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
       b_genweight = (*genweightHandle);
       b_weight = b_genweight*b_puweight;
     }
-    
-    if (sys == sys_nom)
-      h_nevents->Fill(0.5,b_puweight*b_genweight);
-      
+
+    if (sys == sys_nom) h_nevents->Fill(0.5,b_puweight*b_genweight);
+
     edm::Handle<reco::VertexCollection> vertices;
     iEvent.getByToken(vtxToken_, vertices);
     if (vertices->empty()){ // skip the event if no PV found
@@ -694,7 +693,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     selectMuons(*muons, selMuons, (sys_e)sys);
     selectElecs(*electrons, selElecs, (sys_e)sys);
     if ( selMuons.size()+selElecs.size() < 2 ) {
-      if (keepTtbarSignal) ttree_[sys]->Fill();      
+      if (keepTtbarSignal) ttree_[sys]->Fill();
       continue;
     }
     if (sys == sys_nom) cutflow_[3][b_channel]++;
@@ -799,53 +798,53 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
 
       int ijet=0;
       for (auto & jet : selectedJets){
-	jetslv.push_back(jet.p4());
-	jetBtags.push_back(jet.bDiscriminator(BTAG_CSVv2));
-	if (jet.bDiscriminator(BTAG_CSVv2) > WP_BTAG_CSVv2L) bjetIndices.push_back(ijet);
-	jetIndices.push_back(ijet);
-	++ijet;
+        jetslv.push_back(jet.p4());
+        jetBtags.push_back(jet.bDiscriminator(BTAG_CSVv2));
+        if (jet.bDiscriminator(BTAG_CSVv2) > WP_BTAG_CSVv2L) bjetIndices.push_back(ijet);
+        jetIndices.push_back(ijet);
+        ++ijet;
       }
-      
+
       int ilep = 0;
       for (auto & lep : recolep){
-	allLeptonslv.push_back(lep->p4());
-	if (lep->charge() > 0) antiLeptonIndex.push_back(ilep);
-	else leptonIndex.push_back(ilep);
-	++ilep;
-      }      
-      
+        allLeptonslv.push_back(lep->p4());
+        if (lep->charge() > 0) antiLeptonIndex.push_back(ilep);
+        else leptonIndex.push_back(ilep);
+        ++ilep;
+      }
+
       KinematicReconstructionSolutions kinematicReconstructionSolutions  =  kinematicReconstruction->solutions(leptonIndex, antiLeptonIndex, jetIndices, bjetIndices,  allLeptonslv, jetslv, jetBtags, metlv);
 
       if (b_step == 5)
-	if (sys == sys_nom)
-	  cutflow_[10][b_channel]++;
-      
+        if (sys == sys_nom)
+          cutflow_[10][b_channel]++;
+
       if (kinematicReconstructionSolutions.numberOfSolutions()){
-	LV top1 = kinematicReconstructionSolutions.solution().top();
-	LV top2 = kinematicReconstructionSolutions.solution().antiTop();
+        LV top1 = kinematicReconstructionSolutions.solution().top();
+        LV top2 = kinematicReconstructionSolutions.solution().antiTop();
 
-	b_step7 = true;	
-	if (b_step == 5)
-	  if (sys == sys_nom)
-	    cutflow_[11][b_channel]++;
+        b_step7 = true;	
+        if (b_step == 5)
+          if (sys == sys_nom)
+            cutflow_[11][b_channel]++;
 
-	b_desytop1_pt = top1.Pt();
-	b_desytop1_eta = top1.Eta();
-	b_desytop1_phi = top1.Phi();
-	b_desytop1_rapi = top1.Rapidity();
-	b_desytop1_m = top1.M();
-	b_desytop2_pt = top2.Pt();
-	b_desytop2_eta = top2.Eta();
-	b_desytop2_phi = top2.Phi();
-	b_desytop2_rapi = top2.Rapidity();
-	b_desytop2_m = top2.M();
+        b_desytop1_pt = top1.Pt();
+        b_desytop1_eta = top1.Eta();
+        b_desytop1_phi = top1.Phi();
+        b_desytop1_rapi = top1.Rapidity();
+        b_desytop1_m = top1.M();
+        b_desytop2_pt = top2.Pt();
+        b_desytop2_eta = top2.Eta();
+        b_desytop2_phi = top2.Phi();
+        b_desytop2_rapi = top2.Rapidity();
+        b_desytop2_m = top2.M();
 
-	LV ttbar = kinematicReconstructionSolutions.solution().ttbar();
-	b_desyttbar_pt = ttbar.Pt();
-	b_desyttbar_eta = ttbar.Eta();
-	b_desyttbar_dphi = deltaPhi(top1.Phi(), top2.Phi());
-	b_desyttbar_m = ttbar.M();
-	b_desyttbar_rapi = ttbar.Rapidity();
+        LV ttbar = kinematicReconstructionSolutions.solution().ttbar();
+        b_desyttbar_pt = ttbar.Pt();
+        b_desyttbar_eta = ttbar.Eta();
+        b_desyttbar_dphi = deltaPhi(top1.Phi(), top2.Phi());
+        b_desyttbar_m = ttbar.M();
+        b_desyttbar_rapi = ttbar.Rapidity();
       }
     }
     ////////////////////////////////////////////////////////  KIN  /////////////////////////////////////
@@ -902,47 +901,48 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
 
     //saving results
     const double maxweight = sol.quality();
-    bjet1 = sol.j1();
-    bjet2 = sol.j2();
-    top1 = sol.t1();
-    top2 = sol.t2();
-    if (recolep1.charge() < 0) swap(top1, top2);
+    if ( maxweight > 0 ) {
+      bjet1 = sol.j1();
+      bjet2 = sol.j2();
+      top1 = sol.t1();
+      top2 = sol.t2();
+      if (recolep1.charge() < 0) swap(top1, top2);
 
-    if (bjet1.Pt() < bjet2.Pt()) { swap(bjet1, bjet2); }
-    b_jet1_pt = bjet1.Pt();
-    b_jet1_eta = bjet1.Eta();
-    b_jet2_pt = bjet2.Pt();
-    b_jet2_eta = bjet2.Eta();
+      if (bjet1.Pt() < bjet2.Pt()) { swap(bjet1, bjet2); }
+      b_jet1_pt = bjet1.Pt();
+      b_jet1_eta = bjet1.Eta();
+      b_jet2_pt = bjet2.Pt();
+      b_jet2_eta = bjet2.Eta();
 
-    //if (top1.Pt() < top2.Pt()) { swap(top1, top2); }
-    b_top1_pt = top1.Pt();
-    b_top1_eta = top1.Eta();
-    b_top1_phi = top1.Phi();
-    b_top1_rapi = top1.Rapidity();
-    b_top1_m = top1.M();
-    b_top2_pt = top2.Pt();
-    b_top2_eta = top2.Eta();
-    b_top2_phi = top2.Phi();
-    b_top2_rapi = top2.Rapidity();
-    b_top2_m = top2.M();
+      //if (top1.Pt() < top2.Pt()) { swap(top1, top2); }
+      b_top1_pt = top1.Pt();
+      b_top1_eta = top1.Eta();
+      b_top1_phi = top1.Phi();
+      b_top1_rapi = top1.Rapidity();
+      b_top1_m = top1.M();
+      b_top2_pt = top2.Pt();
+      b_top2_eta = top2.Eta();
+      b_top2_phi = top2.Phi();
+      b_top2_rapi = top2.Rapidity();
+      b_top2_m = top2.M();
 
-    auto ttbar = top1+top2;
-    b_ttbar_pt = ttbar.Pt();
-    b_ttbar_eta = ttbar.Eta();
-    b_ttbar_dphi = deltaPhi(top1.Phi(), top2.Phi());
-    b_ttbar_m = ttbar.M();
-    b_ttbar_rapi = ttbar.Rapidity();
+      auto ttbar = top1+top2;
+      b_ttbar_pt = ttbar.Pt();
+      b_ttbar_eta = ttbar.Eta();
+      b_ttbar_dphi = deltaPhi(top1.Phi(), top2.Phi());
+      b_ttbar_m = ttbar.M();
+      b_ttbar_rapi = ttbar.Rapidity();
 
-    b_maxweight = maxweight;
-    if (maxweight>0){
+      b_maxweight = maxweight;
+
       b_step6 = true;
       if (b_step == 5){
         ++b_step;
-	if (sys == sys_nom) cutflow_[9][b_channel]++;
+        if (sys == sys_nom) cutflow_[9][b_channel]++;
       }
+      //  printf("maxweight %f, top1.M() %f, top2.M() %f \n",maxweight, top1.M(), top2.M() );
+      // printf("%2d, %2d, %2d, %2d, %6.2f, %6.2f, %6.2f\n", b_njet, b_nbjet, b_step, b_channel, b_met, b_ll_mass, b_maxweight);
     }
-    //  printf("maxweight %f, top1.M() %f, top2.M() %f \n",maxweight, top1.M(), top2.M() );
-    // printf("%2d, %2d, %2d, %2d, %6.2f, %6.2f, %6.2f\n", b_njet, b_nbjet, b_step, b_channel, b_met, b_ll_mass, b_maxweight);
     ttree_[sys]->Fill();
   }
 }
@@ -1097,7 +1097,7 @@ void TtbarDiLeptonAnalyzer::resetBr()
   b_top2_pt = -9; b_top2_eta = -9; b_top2_phi = -9; b_top2_rapi = -9; b_top2_m = -9;
   b_ttbar_pt = -9; b_ttbar_eta = -9; b_ttbar_dphi = -9; b_ttbar_m = -9; b_ttbar_rapi = -9;
   b_is3lep = -9;
-  
+
   b_desytop1_pt = -9; b_desytop1_eta = -9; b_desytop1_phi = -9; b_desytop1_rapi = -9; b_desytop1_m = -9;
   b_desytop2_pt = -9; b_desytop2_eta = -9; b_desytop2_phi = -9; b_desytop2_rapi = -9; b_desytop2_m = -9;
   b_desyttbar_pt = -9; b_desyttbar_eta = -9; b_desyttbar_dphi = -9; b_desyttbar_m = -9; b_desyttbar_rapi = -9;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -862,7 +862,7 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
       const bool isBjet1 = jet1->bDiscriminator(BTAG_CSVv2) >= WP_BTAG_CSVv2L;
       for (auto jet2 = next(jet1); jet2 != end; ++jet2){
         const auto recojet2= jet2->p4();
-        const bool isBjet2 = jet2->bDiscriminator(BTAG_CSVv2) < WP_BTAG_CSVv2L;
+        const bool isBjet2 = jet2->bDiscriminator(BTAG_CSVv2) >= WP_BTAG_CSVv2L;
 
         inputLV[3] = recojet1;
         inputLV[4] = recojet2;

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -896,8 +896,8 @@ void TtbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSe
     math::XYZTLorentzVector top1, top2, nu1, nu2, bjet1, bjet2;
     // Prefer to select b jets
     cat::KinematicSolution sol;
-    if      ( !sol2Bs.empty() ) sol = sol2Bs.front();
-    else if ( !sol1Bs.empty() ) sol = sol1Bs.front();
+    if      ( !sol2Bs.empty() ) sol = *sol2Bs.begin();
+    else if ( !sol1Bs.empty() ) sol = *sol1Bs.begin();
     //else if ( !sol0Bs.empty() ) sol = sol0Bs.front();
 
     //saving results

--- a/CatAnalyzer/src/KinematicReconstruction.cc
+++ b/CatAnalyzer/src/KinematicReconstruction.cc
@@ -333,6 +333,8 @@ bool KinematicReconstruction::solutionSmearing(KinematicReconstruction_MeanSol& 
             TLorentzVector met_sm;
             TLorentzVector l_sm=l_temp;
             TLorentzVector al_sm=al_temp;
+//#define KINRECONOSM
+#ifndef KINRECONOSM
             //jets energy smearing
             double fB=h_jetEres_->GetRandom();//fB=1;  //sm off
             double xB=sqrt((fB*fB*b_sm.E()*b_sm.E()-b_sm.M2())/(b_sm.P()*b_sm.P()));
@@ -355,12 +357,17 @@ bool KinematicReconstruction::solutionSmearing(KinematicReconstruction_MeanSol& 
             // anti lepton angle smearing
             al_sm.SetXYZT(al_sm.Px()*xaL,al_sm.Py()*xaL,al_sm.Pz()*xaL,al_sm.E()*faL);
             angle_rot(h_lepAngleRes_->GetRandom(),0.001,al_sm,al_sm);
+#endif
             
             
             TVector3 metV3_sm= -b_sm.Vect()-bbar_sm.Vect()-l_sm.Vect()-al_sm.Vect()-vX_reco;
                 met_sm.SetXYZM(metV3_sm.Px(),metV3_sm.Py(),0,0);
             
+#ifndef KINRECONOSM
             KinematicReconstruction_LSroutines tp_sm(h_wmass_->GetRandom(),h_wmass_->GetRandom());
+#else
+            KinematicReconstruction_LSroutines tp_sm(80.4, 80.4);
+#endif
                 tp_sm.setConstraints(al_sm, l_sm, b_sm, bbar_sm, met_sm.Px(), met_sm.Py());
 
             if(tp_sm.getNsol()>0)
@@ -372,6 +379,9 @@ bool KinematicReconstruction::solutionSmearing(KinematicReconstruction_MeanSol& 
                     meanSolution.add(tp_sm.getTtSol()->at(i).top,tp_sm.getTtSol()->at(i).topbar,tp_sm.getTtSol()->at(i).neutrino,tp_sm.getTtSol()->at(i).neutrinobar,mbl_weight);
                 }
             }
+#ifdef KINRECONOSM
+            break;
+#endif
         }
 
 

--- a/CatAnalyzer/src/KinematicReconstruction_LSroutines.cc
+++ b/CatAnalyzer/src/KinematicReconstruction_LSroutines.cc
@@ -402,7 +402,7 @@ void KinematicReconstruction_LSroutines::swap(double& realone, double& realtwo)c
 
 int KinematicReconstruction_LSroutines::sign(const long double& ld)const
 {
-    if(fabs(ld)<0.0000000000001) return 0;
+    if(std::abs(ld)<0.0000000000001) return 0;
     return (ld>0)?1:-1;
 }
 

--- a/CatAnalyzer/src/KinematicSolvers.cc
+++ b/CatAnalyzer/src/KinematicSolvers.cc
@@ -12,8 +12,8 @@ using namespace std;
 
 void TTDileptonSolver::solve(const LV input[])
 {
-  quality_ = -1e9; // default value
-  values_.clear();
+  sol_.quality_ = -1e9; // default value
+  sol_.values_.clear();
 
   const auto& met = input[0];
   const auto& l1 = input[1];
@@ -21,26 +21,26 @@ void TTDileptonSolver::solve(const LV input[])
   const auto& j1 = input[3];
   const auto& j2 = input[4];
 
-  l1_ = input[1]; l2_ = input[2]; j1_ = input[3]; j2_ = input[4];
-  nu1_ = met/2;
-  nu2_ = met/2;
+  sol_.l1_ = input[1]; sol_.l2_ = input[2]; sol_.j1_ = input[3]; sol_.j2_ = input[4];
+  sol_.nu1_ = met/2;
+  sol_.nu2_ = met/2;
 
   const double mW = 80.4;
-  if ( abs((nu1_+l1).mass()-mW)+abs((nu2_+l2).mass()-mW) <
-       abs((nu1_+l2).mass()-mW)+abs((nu2_+l1).mass()-mW) ) swap(nu1_, nu2_);
-  //if ( abs((nu1_+l1).mass()-mW) > 20 or abs((nu2_+l2).mass()-mW) > 20 ) return;
+  if ( abs((sol_.nu1_+l1).mass()-mW)+abs((sol_.nu2_+l2).mass()-mW) <
+       abs((sol_.nu1_+l2).mass()-mW)+abs((sol_.nu2_+l1).mass()-mW) ) swap(sol_.nu1_, sol_.nu2_);
+  //if ( abs((sol_.nu1_+l1).mass()-mW) > 20 or abs((sol_.nu2_+l2).mass()-mW) > 20 ) return;
 
-  quality_ = abs((nu1_+l1+j1).mass()-172.5) + abs((nu2_+l2+j2).mass()-172.5);
-  quality_ = 0.01/(0.01+quality_);
+  sol_.quality_ = abs((sol_.nu1_+l1+j1).mass()-172.5) + abs((sol_.nu2_+l2+j2).mass()-172.5);
+  sol_.quality_ = 0.01/(0.01+sol_.quality_);
 
   //const auto& lb1 = l1+j1;
   //const auto& lb2 = l2+j2;
-  //if ( lb1.mass() > 150 or lb2.mass() > 150 ) quality_ = 0;
+  //if ( lb1.mass() > 150 or lb2.mass() > 150 ) sol_.quality_ = 0;
 
   const auto& vsum = l1+l2+j1+j2+met;
-  if ( vsum.mass() < 300 ) quality_ = 0;
+  if ( vsum.mass() < 300 ) sol_.quality_ = 0;
 
-  values_.push_back(vsum.mass());
+  sol_.values_.push_back(vsum.mass());
 }
 
 namespace CATMT2
@@ -82,15 +82,15 @@ void MT2Solver::solve(const LV input[])
 {
   using namespace CATMT2;
 
-  quality_ = -1e9; // default value
-  values_.clear();
+  sol_.quality_ = -1e9; // default value
+  sol_.values_.clear();
 
   const auto& met = input[0];
   const auto& l1 = input[1];
   const auto& l2 = input[2];
   const auto& j1 = input[3];
   const auto& j2 = input[4];
-  l1_ = input[1]; l2_ = input[2]; j1_ = input[3]; j2_ = input[4];
+  sol_.l1_ = input[1]; sol_.l2_ = input[2]; sol_.j1_ = input[3]; sol_.j2_ = input[4];
 
   // pars : bx1, by1, bx2, by2, Kx, Ky, xmin, xmax
   //        b : b jet px, py
@@ -133,9 +133,9 @@ void MT2Solver::solve(const LV input[])
   const double qx2 = met.px()+l1.px()+l2.px()-qx1;
   const double qy2 = met.py()+l1.py()+l2.py()-qy1;
   const double mt2 = sqrt(mtsqr(qx1, qy1, pars[0], pars[1]));
-  quality_ = 1;
+  sol_.quality_ = 1;
   // For debug : print out mt2(qx1, qy1) vs mt2(qx2, qy2).
-  // If minimization was failed, mt2_A != mt2_B
+  // If minimization was failed, msol_.t2_A != msol_.t2_B
   // Of course this is not full test of minimization, but this must be the very first observable
   // cout << sqrt(mtsqr(qx1, qy1, pars[0], pars[1]))-sqrt(mtsqr(qx2, qy2, pars[2], pars[3])) << endl;
 
@@ -143,10 +143,10 @@ void MT2Solver::solve(const LV input[])
   const double ew2 = sqrt(mwsqr + qx2*qx2 + qy2*qy2);
   LV w1(qx1, qy1, 0, ew1);
   LV w2(qx2, qy2, 0, ew2);
-  nu1_ = w1-l1;
-  nu2_ = w2-l2;
+  sol_.nu1_ = w1-l1;
+  sol_.nu2_ = w2-l2;
 
-  values_.push_back(mt2);
+  sol_.values_.push_back(mt2);
 
 }
 
@@ -169,8 +169,8 @@ CMSKinSolver::CMSKinSolver(const edm::ParameterSet& pset): KinematicSolver(pset)
 
 void CMSKinSolver::solve(const LV input[])
 {
-  quality_ = -1e9; // default value
-  values_.clear();
+  sol_.quality_ = -1e9; // default value
+  sol_.values_.clear();
 
   const double metX = input[0].px();
   const double metY = input[0].py();
@@ -182,18 +182,18 @@ void CMSKinSolver::solve(const LV input[])
   solver_->SetConstraints(metX+l1.Px()+j1.Px()+l2.Px()+j2.Px(),
                           metY+l1.Py()+j1.Py()+l2.Py()+j2.Py());
   auto nuSol = solver_->getNuSolution(l1, l2, j1, j2);
-  quality_  = nuSol.weight;
-  if ( quality_ < 0 ) return;
+  sol_.quality_  = nuSol.weight;
+  if ( sol_.quality_ < 0 ) return;
 
-  nu1_ = nuSol.neutrino.p4();
-  nu2_ = nuSol.neutrinoBar.p4();
-  l1_ = input[1]; l2_ = input[2]; j1_ = input[3]; j2_ = input[4];
+  sol_.nu1_ = nuSol.neutrino.p4();
+  sol_.nu2_ = nuSol.neutrinoBar.p4();
+  sol_.l1_ = input[1]; sol_.l2_ = input[2]; sol_.j1_ = input[3]; sol_.j2_ = input[4];
 
-  const LV t1 = input[1]+input[3]+nu1_;
-  const LV t2 = input[2]+input[4]+nu2_;
-  values_.push_back((t1+t2).mass());
-  values_.push_back(t1.mass());
-  values_.push_back(t2.mass());
+  const LV t1 = input[1]+input[3]+sol_.nu1_;
+  const LV t2 = input[2]+input[4]+sol_.nu2_;
+  sol_.values_.push_back((t1+t2).mass());
+  sol_.values_.push_back(t1.mass());
+  sol_.values_.push_back(t2.mass());
 }
 
 DESYMassLoopSolver::DESYMassLoopSolver(const edm::ParameterSet& pset):
@@ -206,8 +206,8 @@ DESYMassLoopSolver::DESYMassLoopSolver(const edm::ParameterSet& pset):
 
 void DESYMassLoopSolver::solve(const LV input[])
 {
-  quality_ = -1e9;
-  values_.clear();
+  sol_.quality_ = -1e9;
+  sol_.values_.clear();
 
   const double metX = input[0].px(), metY = input[0].py();
   const auto& l1 = input[1], l2 = input[2];
@@ -238,14 +238,14 @@ void DESYMassLoopSolver::solve(const LV input[])
       const double ttE = visSum.E()+nu1sol[3]+nu2sol[3];
       const double weight = 1/sqrt(ttE*ttE-ttX*ttX-ttY*ttY-ttZ*ttZ);
 
-      if ( weight < quality_ ) continue;
+      if ( weight < sol_.quality_ ) continue;
 
-      quality_ = weight;
-      nu1_.SetPxPyPzE(nu1sol[0], nu1sol[1], nu1sol[2], nu1sol[3]);
-      nu2_.SetPxPyPzE(nu2sol[0], nu2sol[1], nu2sol[2], nu2sol[3]);
+      sol_.quality_ = weight;
+      sol_.nu1_.SetPxPyPzE(nu1sol[0], nu1sol[1], nu1sol[2], nu1sol[3]);
+      sol_.nu2_.SetPxPyPzE(nu2sol[0], nu2sol[1], nu2sol[2], nu2sol[3]);
     }
   }
-  l1_ = input[1]; l2_ = input[2]; j1_ = input[3]; j2_ = input[4];
+  sol_.l1_ = input[1]; sol_.l2_ = input[2]; sol_.j1_ = input[3]; sol_.j2_ = input[4];
 }
 
 DESYSmearedSolver::DESYSmearedSolver(const edm::ParameterSet& pset):
@@ -278,8 +278,8 @@ DESYSmearedSolver::DESYSmearedSolver(const edm::ParameterSet& pset):
 
 void DESYSmearedSolver::solve(const LV input[])
 {
-  quality_ = -1e9;
-  values_.clear();
+  sol_.quality_ = -1e9;
+  sol_.values_.clear();
 
   const double metX = input[0].px(), metY = input[0].py();
   const auto& l1 = input[1], l2 = input[2];
@@ -371,22 +371,22 @@ void DESYSmearedSolver::solve(const LV input[])
     sumP[4][0] += weight*nu1sol[0]; sumP[4][1] += weight*nu1sol[1]; sumP[4][2] += weight*nu1sol[2];
     sumP[5][0] += weight*nu2sol[0]; sumP[5][1] += weight*nu2sol[1]; sumP[5][2] += weight*nu2sol[2];
   }
-  quality_ = sumW;
-  if ( quality_ <= 0 ) { quality_ = -1e9; return; }
+  sol_.quality_ = sumW;
+  if ( sol_.quality_ <= 0 ) { sol_.quality_ = -1e9; return; }
   for ( int i=0; i<6; ++i ) for ( int j=0; j<3; ++j ) sumP[i][j] /= sumW;
 
-  l1_.SetXYZT(sumP[0][0], sumP[0][1], sumP[0][2], KinSolverUtils::computeEnergy(sumP[0], KinSolverUtils::mL));
-  l2_.SetXYZT(sumP[1][0], sumP[1][1], sumP[1][2], KinSolverUtils::computeEnergy(sumP[1], KinSolverUtils::mL));
-  j1_.SetXYZT(sumP[2][0], sumP[2][1], sumP[2][2], KinSolverUtils::computeEnergy(sumP[2], KinSolverUtils::mB));
-  j2_.SetXYZT(sumP[3][0], sumP[3][1], sumP[3][2], KinSolverUtils::computeEnergy(sumP[3], KinSolverUtils::mB));
-  nu1_.SetXYZT(sumP[4][0], sumP[4][1], sumP[4][2], KinSolverUtils::computeEnergy(sumP[4], KinSolverUtils::mV));
-  nu2_.SetXYZT(sumP[5][0], sumP[5][1], sumP[5][2], KinSolverUtils::computeEnergy(sumP[5], KinSolverUtils::mV));
-  t1_ = l1_+j1_+nu1_;
-  t2_ = l2_+j2_+nu2_;
-  const double p1[] = {t1_.px(), t1_.py(), t1_.pz()};
-  const double p2[] = {t2_.px(), t2_.py(), t2_.pz()};
-  t1_.SetE(KinSolverUtils::computeEnergy(p1, mTopInput_));
-  t2_.SetE(KinSolverUtils::computeEnergy(p2, mTopInput_));
+  sol_.l1_.SetXYZT(sumP[0][0], sumP[0][1], sumP[0][2], KinSolverUtils::computeEnergy(sumP[0], KinSolverUtils::mL));
+  sol_.l2_.SetXYZT(sumP[1][0], sumP[1][1], sumP[1][2], KinSolverUtils::computeEnergy(sumP[1], KinSolverUtils::mL));
+  sol_.j1_.SetXYZT(sumP[2][0], sumP[2][1], sumP[2][2], KinSolverUtils::computeEnergy(sumP[2], KinSolverUtils::mB));
+  sol_.j2_.SetXYZT(sumP[3][0], sumP[3][1], sumP[3][2], KinSolverUtils::computeEnergy(sumP[3], KinSolverUtils::mB));
+  sol_.nu1_.SetXYZT(sumP[4][0], sumP[4][1], sumP[4][2], KinSolverUtils::computeEnergy(sumP[4], KinSolverUtils::mV));
+  sol_.nu2_.SetXYZT(sumP[5][0], sumP[5][1], sumP[5][2], KinSolverUtils::computeEnergy(sumP[5], KinSolverUtils::mV));
+  sol_.t1_ = sol_.l1_+sol_.j1_+sol_.nu1_;
+  sol_.t2_ = sol_.l2_+sol_.j2_+sol_.nu2_;
+  const double p1[] = {sol_.t1_.px(), sol_.t1_.py(), sol_.t1_.pz()};
+  const double p2[] = {sol_.t2_.px(), sol_.t2_.py(), sol_.t2_.pz()};
+  sol_.t1_.SetE(KinSolverUtils::computeEnergy(p1, mTopInput_));
+  sol_.t2_.SetE(KinSolverUtils::computeEnergy(p2, mTopInput_));
 
 }
 

--- a/CatAnalyzer/src/TopKinSolverUtils.cc
+++ b/CatAnalyzer/src/TopKinSolverUtils.cc
@@ -31,7 +31,7 @@ void KinSolverUtils::findCoeffs(const double mT, const double mW1, const double 
   const double l2E = l2.energy(), j2E = j2.energy();
   const double jlEA = j2E + l2E;
   const double divA = 2*l2E*jlEA;
-  const double a1 = (jlEA*dmW1-l2E*(dmT-2*j2E*l2E+2*(l2.Vect().Dot(j2.Vect()))))/divA;
+  const double a1 = (jlEA*dmW2-l2E*(dmT-2*j2E*l2E+2*(l2.Vect().Dot(j2.Vect()))))/divA;
   const double a2 = 2*(j2E*l2.px()-l2E*j2.px())/divA;
   const double a3 = 2*(j2E*l2.py()-l2E*j2.py())/divA;
   const double a4 = 2*(j2E*l2.pz()-l2E*j2.pz())/divA;
@@ -39,7 +39,7 @@ void KinSolverUtils::findCoeffs(const double mT, const double mW1, const double 
   const double l1E = l1.energy(), j1E = j1.energy();
   const double jlEB = j1E + l1E;
   const double divB = 2*l1E*jlEB;
-  const double b1 = (jlEB*dmW2-l1E*(dmT-2*j1E*l1E+2*(l1.Vect().Dot(j1.Vect()))))/divB;
+  const double b1 = (jlEB*dmW1-l1E*(dmT-2*j1E*l1E+2*(l1.Vect().Dot(j1.Vect()))))/divB;
   const double b2 = 2*(j1E*l1.px()-l1E*j1.px())/divB;
   const double b3 = 2*(j1E*l1.py()-l1E*j1.py())/divB;
   const double b4 = 2*(j1E*l1.pz()-l1E*j1.pz())/divB;
@@ -49,18 +49,18 @@ void KinSolverUtils::findCoeffs(const double mT, const double mW1, const double 
   const double c00 = -4*(dxsqr(l2E, l2.py()) + dxsqr(l2E, l2.pz())*a34*a34 + 2*l2.py()*l2.pz()*a34)/divC;
   const double c10 = -8*(dxsqr(l2E, l2.pz())*a24*a34 - l2.px()*l2.py() + l2.px()*l2.pz()*a34 + l2.py()*l2.pz()*a24)/divC;
   const double c20 = -4*(dxsqr(l2E, l2.px()) + dxsqr(l2E, l2.pz())*a24*a24 + 2*l2.px()*l2.pz()*a24)/divC;
-  const double c11 = 4*(dmW1*(l2.py()-l2.pz()*a34)-2*dxsqr(l2E, l2.pz())*a14*a34-2*l2.py()*l2.pz()*a14)/divC;
-  const double c21 = 4*(dmW1*(l2.px()-l2.pz()*a24)-2*dxsqr(l2E, l2.pz())*a14*a24-2*l2.px()*l2.pz()*a14)/divC;
-  const double c22 = (dmW1*dmW1-4*dxsqr(l2E, l2.pz())*a14*a14-4*dmW1*l2.pz()*a14)/divC;
+  const double c11 = 4*(dmW2*(l2.py()-l2.pz()*a34)-2*dxsqr(l2E, l2.pz())*a14*a34-2*l2.py()*l2.pz()*a14)/divC;
+  const double c21 = 4*(dmW2*(l2.px()-l2.pz()*a24)-2*dxsqr(l2E, l2.pz())*a14*a24-2*l2.px()*l2.pz()*a14)/divC;
+  const double c22 = (dmW2*dmW2-4*dxsqr(l2E, l2.pz())*a14*a14-4*dmW2*l2.pz()*a14)/divC;
 
   const double divD = 4*jlEB*jlEB;
   const double b14 = b1/b4, b24 = b2/b4, b34 = b3/b4;
   const double d00 = -4*(dxsqr(l1E, l1.py()) + dxsqr(l1E, l1.pz())*b34*b34 + 2*l1.py()*l1.pz()*b34)/divD;
   const double d10 = -8*(dxsqr(l1E, l1.pz())*b24*b34 - l1.px()*l1.py() + l1.px()*l1.pz()*b34 + l1.py()*l1.pz()*b24)/divD;
   const double d20 = -4*(dxsqr(l1E, l1.px()) + dxsqr(l1E, l1.pz())*b24*b24 + 2*l1.px()*l1.pz()*b24)/divD;
-  const double d11 = 4*(dmW2*(l1.py()-l1.pz()*b34)-2*dxsqr(l1E, l1.pz())*b14*b34-2*l1.py()*l1.pz()*b14)/divD;
-  const double d21 = 4*(dmW2*(l1.px()-l1.pz()*b24)-2*dxsqr(l1E, l1.pz())*b14*b24-2*l1.px()*l1.pz()*b14)/divD;
-  const double d22 = (dmW2*dmW2-4*dxsqr(l1E, l1.pz())*b14*b14-4*dmW2*l1.pz()*b14)/divD;
+  const double d11 = 4*(dmW1*(l1.py()-l1.pz()*b34)-2*dxsqr(l1E, l1.pz())*b14*b34-2*l1.py()*l1.pz()*b14)/divD;
+  const double d21 = 4*(dmW1*(l1.px()-l1.pz()*b24)-2*dxsqr(l1E, l1.pz())*b14*b24-2*l1.px()*l1.pz()*b14)/divD;
+  const double d22 = (dmW1*dmW1-4*dxsqr(l1E, l1.pz())*b14*b14-4*dmW1*l1.pz()*b14)/divD;
 
   const double f22 = d22+sqr(metX)*d20+sqr(metY)*d00+metX*metY*d10+metX*d21+metY*d11;
   const double f21 = -d21-2*metX*d20-metY*d10;


### PR DESCRIPTION
Give priority to the solution with more b tagged jets.
In addition to this, at least one b tagged jet is required to be included in the kinematic solution.

To enable these selections, add a struct to save KinSolver result. This makes analyzers to manager kinsolver results in their analysis module.
