### PR TITLE
Quick fix for the correct scale variation weights

### DIFF
--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -134,8 +134,9 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
 
       const string weightTypeStr = weightTypeObj->GetValue();
       int weightType = 0;
-      if ( weightTypeStr.substr(0, 5) == "scale" ) weightType = 1;
-      else if ( weightTypeStr.substr(0, 3) == "PDF" ) weightType = 2;
+      if ( weightTypeStr.find("scale") != string::npos ) weightType = 1;
+      //else if ( weightTypeStr.substr(0, 3) == "PDF" ) weightType = 2;
+      else weightType = 2;
       int weightSize = 0;
       vstring weightParams, weightKeys;
       for ( TXMLNode* weightNode = grpNode->GetChildren(); weightNode != 0; weightNode = weightNode->GetNextNode() )


### PR DESCRIPTION
GenWeight for the madgraph samples were not correctly ordered in 764 samples. #516 
This is because each generators have different lhe header tags and attributes to store the weight information.

Users can avoid the problem simply forcing the weights to be 1 for the madgraph samples or get the weights from the otherWeights vector.
