### PR TITLE
use the reference trigger selection

### DIFF
--- a/CatAnalyzer/python/filters_cff.py
+++ b/CatAnalyzer/python/filters_cff.py
@@ -44,6 +44,7 @@ filterTrigELEL = filterTrigMUEL.clone(
 filterTrigMUMU = filterTrigMUEL.clone(
     triggersToMatch = cms.vstring(
         "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v",
+        "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ_v",
     ),
 )
 


### PR DESCRIPTION
One of the trigger path was missing in the cfg file.
This is necessary to use the reference trigger scale factors.
