### PR TITLE
Generic way to split genWeights

### DIFF
--- a/CatAnalyzer/test/run_TtbarBbbarDiLeptonAnalyzer_cfg.py
+++ b/CatAnalyzer/test/run_TtbarBbbarDiLeptonAnalyzer_cfg.py
@@ -11,14 +11,11 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 #process.source.fileNames.append('/store/user/jhgoh/CATTools/sync/v7-6-1/TTbarXSecSynchronization_76X_MC_TT_powheg.root')
-
-process.source.fileNames = ['root://cms-xrdr.sdfarm.kr:1094///xrd/store/group/CAT/TT_TuneCUETP8M1_13TeV-powheg-pythia8/v7-6-5_RunIIFall15MiniAODv2-PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext3-v1/160524_090311/0000/catTuple_1.root',]
-
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/TT_TuneCUETP8M1_13TeV-powheg-pythia8.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/DoubleEG_Run2015D-16Dec2015-v2.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/DoubleMuon_Run2015D-16Dec2015-v1.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/MuonEG_Run2015D-16Dec2015-v1.root',]
+process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-5/TT_TuneCUETP8M1_13TeV-powheg-pythia8.root',]
+#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-5/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8.root',]
+#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-5/DoubleEG_Run2015D-16Dec2015-v2.root',]
+#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-5/DoubleMuon_Run2015D-16Dec2015-v1.root',]
+#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-5/MuonEG_Run2015D-16Dec2015-v1.root',]
 
 #import os
 #useGold = True

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -19,6 +19,8 @@
 #include <TDOMParser.h>
 #include <TXMLNode.h>
 #include <TXMLAttr.h>
+#include <regex>
+#include <boost/lexical_cast.hpp>
 
 #include <memory>
 #include <vector>
@@ -79,18 +81,52 @@ void GenWeightsToFlatWeights::beginRun(const edm::Run& run, const edm::EventSetu
       const auto& params = srcHandle->params(i);
       for ( int j=1, m=keys.size(); j<m; ++j ) {
         string par = params[j];
-        std::transform(par.begin(), par.end(), par.begin(), ::toupper);
         // Skip unphysical combinations
-        // up=(1002, 1004, 1005), down=(1003, 1007, 1009), unphysical=(1006, 1008)
-        if ( par.find("5") != string::npos and par.find("2") != string::npos ) continue;
+        // By fixed index: up=(1002, 1004, 1005), down=(1003, 1007, 1009), unphysical=(1006, 1008)
+        // Or by matching to the muR and muF parameters
+        // First, cleanup the string
+        std::transform(par.begin(), par.end(), par.begin(), ::toupper);
+        par.erase(std::remove(par.begin(), par.end(), '_'), par.end());
+        std::replace(par.begin(), par.end(), '=', ' ');
+        // Then tokenize parameter string
+        std::vector<std::string> tokens;
+        std::regex ws_re("\\s+"); // whitespace
+        std::copy(std::sregex_token_iterator(par.begin(), par.end(), ws_re, -1),
+                  std::sregex_token_iterator(), std::back_inserter(tokens));
+        double muR = 0, muF = 0;
+        for ( int iToken=0, nToken=tokens.size(); iToken<nToken; ++iToken) {
+          if ( tokens[iToken] == "MUR" and iToken+1 < nToken ) {
+            const double orig = muR;
+            try { muR = boost::lexical_cast<double>(tokens[++iToken]); }
+            catch ( boost::bad_lexical_cast ) { muR = orig; }
+          }
+          if ( tokens[iToken] == "MUF" and iToken+1 < nToken ) {
+            const double orig = muF;
+            try { muF = boost::lexical_cast<double>(tokens[++iToken]); }
+            catch ( boost::bad_lexical_cast ) { muF = orig; }
+          }
+        }
+        if ( (muR == 0 or muF == 0) or (muR > 1.5 and muF < 0.7) or (muR < 0.7 and muF > 1.5 ) ) {
+          cout << "@@@ Skipping unphysical parameter" << params[j] << endl;
+          continue;
+        }
 
         const size_t key = keys[j];
-        if      ( par.find("2") != string::npos ) key_sup_.insert(key);
-        else if ( par.find("5") != string::npos ) key_sdn_.insert(key);
+        if      ( muR > 1.5 or muF > 1.5 ) {
+          cout << "@@@ Inserting into scaleup weight[" << (key_sup_.size()) << "]" << params[j] << endl;
+          key_sup_.insert(key);
+        }
+        else if ( muR < 0.7 or muF < 0.7 ) {
+          cout << "@@@ Inserting into scaledown weight[" << (key_sdn_.size()) << "]" << params[j] << endl;
+          key_sdn_.insert(key);
+        }
       }
     }
     else if ( name.find("PDF") != string::npos ) {
-      if ( doKeepFirstOnly_ and !key_pdf_.empty() ) continue;
+      if ( doKeepFirstOnly_ and !key_pdf_.empty() ) {
+        cout << "@@@ Skipping PDF weight " << name << " since the first weight group is already set " << endl;
+        continue;
+      }
       key_pdf_.insert(keys.begin(), keys.end());
     }
     else if ( doSaveOthers_ ) {

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -66,7 +66,7 @@ GenWeightsToFlatWeights::GenWeightsToFlatWeights(const edm::ParameterSet& pset):
 void GenWeightsToFlatWeights::beginRun(const edm::Run& run, const edm::EventSetup&)
 {
   edm::Handle<cat::GenWeightInfo> srcHandle;
-  run.getByLabel(srcLabel_, srcHandle);
+  if ( !run.getByLabel(srcLabel_, srcHandle) ) return;
 
   for ( int i=0, n=srcHandle->nGroups(); i<n; ++i ) {
     const auto& keys = srcHandle->keys(i);


### PR DESCRIPTION
Now the scale weights are split based on the actual muR and muF parameters in generic way.
Some basic level of string parsing was done to determine the scale parameters.
