### PR TITLE
use default miniAOD jet pt and fix pileup using 2015 (needs to be fixed)

### DIFF
--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -65,6 +65,22 @@ miniAOD_customizeOutput(process.catOut)
     
 process.catOutpath = cms.EndPath(process.catOut)    
 process.schedule.append(process.catOutpath)
+
+
+#### pileup weight
+import CATTools.CatProducer.catDefinitions_cfi as cat
+lumiJSON = "Cert_246908-260627_13TeV_PromptReco_Collisions15_25ns_JSON"
+if runOnMC:
+        from CATTools.CatProducer.pileupWeight_cff import pileupWeightMap
+        process.pileupWeight.pileupMC = pileupWeightMap[cat.pileupMCmap]
+        process.pileupWeight.pileupRD = pileupWeightMap["%s"%lumiJSON]
+        process.pileupWeight.pileupUp = pileupWeightMap["%s_Up"%lumiJSON]
+        process.pileupWeight.pileupDn = pileupWeightMap["%s_Dn"%lumiJSON]
+else:
+        from FWCore.PythonUtilities.LumiList import LumiList
+        process.lumiMask = cms.EDProducer("LumiMaskProducer",
+            LumiSections = LumiList('../data/LumiMask/%s.txt'%lumiJSON).getVLuminosityBlockRange())
+
 ####################################################################
 #### setting up cat tools
 ####################################################################
@@ -83,12 +99,10 @@ process.maxEvents.input = options.maxEvents
 # Default file here for test purpose
 if not options.inputFiles:
     if useMiniAOD:
-        if runGenTop:
-            process.source.fileNames = [
-                                      '/store/relval/CMSSW_7_4_15/RelValTTbar_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/0253820F-4772-E511-ADD3-002618943856.root',
-                                      '/store/relval/CMSSW_7_4_15/RelValTTbar_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/3848030E-4772-E511-AFCA-0026189438CC.root']
-        else:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_15/RelValZMM_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/10FF6E32-3C72-E511-87AD-0025905A60B4.root']
+        process.source.fileNames = [
+        '/store/relval/CMSSW_8_0_5/RelValTTbarLepton_13/MINIAODSIM/80X_mcRun2_asymptotic_v12_gs7120p2-v1/00000/16CCD76F-F408-E611-BC3F-0025905B8582.root',
+        '/store/relval/CMSSW_8_0_5/RelValTTbarLepton_13/MINIAODSIM/80X_mcRun2_asymptotic_v12_gs7120p2-v1/00000/907D986F-F408-E611-84A0-0025905A60F4.root',
+        ]
     else:
         if useGenTop:
             process.source.fileNames = ['/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/006F3660-4B5E-E511-B8FD-0025905B8596.root']

--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -2,16 +2,6 @@ import FWCore.ParameterSet.Config as cms
 import catDefinitions_cfi as cat
 
 def catTool(process, runOnMC=True, useMiniAOD=True):
-    if runOnMC:
-        from CATTools.CatProducer.pileupWeight_cff import pileupWeightMap
-        process.pileupWeight.pileupMC = pileupWeightMap[cat.pileupMCmap]
-        process.pileupWeight.pileupRD = pileupWeightMap["%s"%cat.lumiJSON]
-        process.pileupWeight.pileupUp = pileupWeightMap["%s_Up"%cat.lumiJSON]
-        process.pileupWeight.pileupDn = pileupWeightMap["%s_Dn"%cat.lumiJSON]
-    else:
-        from FWCore.PythonUtilities.LumiList import LumiList
-        process.lumiMask = cms.EDProducer("LumiMaskProducer",
-            LumiSections = LumiList('../data/LumiMask/%s.txt'%cat.lumiJSON).getVLuminosityBlockRange())
     
     useJECfile = True
     jecFile = cat.JetEnergyCorrection
@@ -73,7 +63,7 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         ## applying new jec on the fly
         process.load("PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff")
         process.patJetCorrFactors.primaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices")
-        process.catJets.src = cms.InputTag("updatedPatJets")
+        #process.catJets.src = cms.InputTag("updatedPatJets") # do we neeed to update JEC for 80x?
         ### updating puppi jet jec
         process.patJetPuppiCorrFactorsUpdated = process.updatedPatJetCorrFactors.clone(
             src = process.catJetsPuppi.src,
@@ -94,7 +84,8 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         #)
         #process.patJetsUpdated.userData.userFloats.src +=['pileupJetIdUpdated:fullDiscriminant']
 
-        process.catJets.src = cms.InputTag("patJetsUpdated")
+        #Do we need this? (TJ)
+        #process.catJets.src = cms.InputTag("patJetsUpdated")
 
         
         process.catJetsPuppi.src = cms.InputTag("patJetsPuppiUpdated")


### PR DESCRIPTION
1. pileup weight needs to be updated.
   currently it is using 2015 weight just to make the code work
2. use default MINIAOD jet pt unless updating jet pt is really needed. 
