### PR TITLE
Run Run2016 data

### DIFF
--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 import catDefinitions_cfi as cat
+import os
+print os.environ['CMSSW_BASE']
 
 def catTool(process, runOnMC=True, useMiniAOD=True):
     if runOnMC:
@@ -11,7 +13,7 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
     else:
         from FWCore.PythonUtilities.LumiList import LumiList
         process.lumiMask = cms.EDProducer("LumiMaskProducer",
-            LumiSections = LumiList('../data/LumiMask/%s.txt'%cat.lumiJSON).getVLuminosityBlockRange())
+            LumiSections = LumiList('%s/src/CATTools/CatProducer/data/LumiMask/%s.txt'%(os.environ['CMSSW_BASE'], cat.lumiJSON)).getVLuminosityBlockRange())
     
     useJECfile = True
     jecFile = cat.JetEnergyCorrection
@@ -94,9 +96,6 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         #)
         #process.patJetsUpdated.userData.userFloats.src +=['pileupJetIdUpdated:fullDiscriminant']
 
-        process.catJets.src = cms.InputTag("patJetsUpdated")
-
-        
         process.catJetsPuppi.src = cms.InputTag("patJetsPuppiUpdated")
         process.catJetsPuppi.setGenParticle = cms.bool(False)
         ## #######################################################################

--- a/CatProducer/test/runtests.sh
+++ b/CatProducer/test/runtests.sh
@@ -2,18 +2,18 @@
 
 function die { echo $1: status $2 ;  exit $2; }
 
-cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
-  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runOnRelVal=1' \
-  'inputFiles=/store/relval/CMSSW_7_6_2/RelValZMM_13/MINIAODSIM/76X_mcRun2_asymptotic_v12-v1/00000/027AB257-A09C-E511-8F3D-003048FFD736.root' \
-  || die 'Failure to run PAT2CAT from MiniAODSIM' $?
+#cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
+#  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runOnRelVal=1' \
+#  'inputFiles=/store/relval/CMSSW_7_6_2/RelValZMM_13/MINIAODSIM/76X_mcRun2_asymptotic_v12-v1/00000/027AB257-A09C-E511-8F3D-003048FFD736.root' \
+#  || die 'Failure to run PAT2CAT from MiniAODSIM' $?
 
-cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
-  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'runOnRelVal=1' \
-  'inputFiles=/store/relval/CMSSW_7_6_2/RelValTTbar_13/MINIAODSIM/76X_mcRun2_asymptotic_v12-v1/00000/0A10678B-8D9C-E511-8AB3-0CC47A4D75F6.root' \
-  || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
+#cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
+#  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'runOnRelVal=1' \
+#  'inputFiles=/store/relval/CMSSW_7_6_2/RelValTTbar_13/MINIAODSIM/76X_mcRun2_asymptotic_v12-v1/00000/0A10678B-8D9C-E511-8AB3-0CC47A4D75F6.root' \
+#  || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=0' 'useMiniAOD=1' \
-  'inputFiles=/store/data/Run2015C/DoubleMuon/MINIAOD/PromptReco-v1/000/254/790/00000/22890CFA-034A-E511-A23D-02163E011EC1.root' \
+  'inputFiles= /store/data/Run2016B/DoubleMuon/MINIAOD/PromptReco-v2/000/274/442/00000/0496E479-DD2D-E611-81D3-02163E0144B6.root' \
   || die 'Failure to run PAT2CAT from MiniAOD real data' $?
 


### PR DESCRIPTION
Some basic setup to avoid crash.
@monttj this PR does not change JEC flag, thus it will be applied on the fly.

```
cmsrel CMSSW_8_0_10
cd CMSSW_8_0_10/src
cmsenv
git remote add vallot https://github.com/vallot/cmssw
git fetch vallot
git checkout -b cat80x vallot/cat80x
git-cms-addpkg EgammaAnalysis
git clone https://github.com/vallot/CATTools
cd CATTools
git checkout cat80x
git submodule init
git submodule update
cd ..
scram b -j8
cd CATTools/CatProducer/test
scram b runtests
```
