### PR TITLE
Redo the pileup weight on the fly

### DIFF
--- a/CatAnalyzer/test/run_TtbarBbbarDiLeptonAnalyzer_cfg.py
+++ b/CatAnalyzer/test/run_TtbarBbbarDiLeptonAnalyzer_cfg.py
@@ -53,6 +53,16 @@ process.load("CATTools.CatAnalyzer.flatGenWeights_cfi")
 
 from CATTools.CatAnalyzer.leptonSF_cff import *
 
+## Redo the pileup weight - necessary for v765 production
+process.load("CATTools.CatProducer.pileupWeight_cff")
+process.redoPileupWeight = process.pileupWeight.clone()
+from CATTools.CatProducer.pileupWeight_cff import pileupWeightMap
+process.redoPileupWeight.weightingMethod = "RedoWeight"
+process.redoPileupWeight.pileupMC = pileupWeightMap["2015_25ns_FallMC"]
+process.redoPileupWeight.pileupRD = pileupWeightMap["Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON"]
+process.redoPileupWeight.pileupUp = pileupWeightMap["Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_Up"]
+process.redoPileupWeight.pileupDn = pileupWeightMap["Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_Dn"]
+
 process.cattree = cms.EDAnalyzer("TtbarBbbarDiLeptonAnalyzer",
     recoFilters = cms.InputTag("filterRECO"),
     nGoodVertex = cms.InputTag("catVertex","nGoodPV"),
@@ -65,7 +75,8 @@ process.cattree = cms.EDAnalyzer("TtbarBbbarDiLeptonAnalyzer",
     lumiSelection = cms.InputTag(lumiMask),
     puweight = cms.InputTag("pileupWeight"),
     puweightUp = cms.InputTag("pileupWeight","up"),
-    puweightDown = cms.InputTag("pileupWeight","dn"),
+    #puweightDown = cms.InputTag("pileupWeight","dn"),
+    puweightDown = cms.InputTag("redoPileupWeight","dn"), ## Redo the pileup weight for downward variation in v765 prod
     trigMUEL = cms.InputTag("filterTrigMUEL"),
     trigMUMU = cms.InputTag("filterTrigMUMU"),
     trigELEL = cms.InputTag("filterTrigELEL"),

--- a/CatAnalyzer/test/run_TtbarDiLeptonAnalyzer_cfg.py
+++ b/CatAnalyzer/test/run_TtbarDiLeptonAnalyzer_cfg.py
@@ -26,6 +26,17 @@ process.load("CATTools.CatAnalyzer.topPtWeightProducer_cfi")
 process.load("CATTools.CatAnalyzer.flatGenWeights_cfi")
 from CATTools.CatAnalyzer.leptonSF_cff import *
 
+## Redo the pileup weight - necessary for v765 production
+process.load("CATTools.CatProducer.pileupWeight_cff")
+process.redoPileupWeight = process.pileupWeight.clone()
+from CATTools.CatProducer.pileupWeight_cff import pileupWeightMap
+process.redoPileupWeight.weightingMethod = "RedoWeight"
+process.redoPileupWeight.pileupMC = pileupWeightMap["2015_25ns_FallMC"]
+process.redoPileupWeight.pileupRD = pileupWeightMap["Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON"]
+process.redoPileupWeight.pileupUp = pileupWeightMap["Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_Up"]
+process.redoPileupWeight.pileupDn = pileupWeightMap["Cert_13TeV_16Dec2015ReReco_Collisions15_25ns_JSON_Dn"]
+pileupWeight = 'redoPileupWeight'
+
 process.ttbarDileptonKinAlgoPSetDESYSmeared.inputTemplatePath = cms.string("CATTools/CatAnalyzer/data/desyKinRecoInput.root")
 process.ttbarDileptonKinAlgoPSetDESYSmeared.maxLBMass = cms.double(180)
 process.ttbarDileptonKinAlgoPSetDESYSmeared.mTopInput = cms.double(172.5)

--- a/CatProducer/plugins/CATPileupWeightProducer.cc
+++ b/CatProducer/plugins/CATPileupWeightProducer.cc
@@ -20,11 +20,11 @@
 
 using namespace std;
 
-class PileupWeightProducer : public edm::stream::EDProducer<>
+class CATPileupWeightProducer : public edm::stream::EDProducer<>
 {
 public:
-  PileupWeightProducer(const edm::ParameterSet& pset);
-  ~PileupWeightProducer() {};
+  CATPileupWeightProducer(const edm::ParameterSet& pset);
+  ~CATPileupWeightProducer() {};
 
   void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
@@ -43,7 +43,7 @@ private:
   edm::EDGetTokenT<int> nTrueIntrToken_;
 };
 
-PileupWeightProducer::PileupWeightProducer(const edm::ParameterSet& pset)
+CATPileupWeightProducer::CATPileupWeightProducer(const edm::ParameterSet& pset)
 {
   const string methodName = pset.getParameter<string>("weightingMethod");
   if      ( methodName == "Standard" ) weightingMethod_ = WeightingMethod::Standard;
@@ -54,7 +54,7 @@ PileupWeightProducer::PileupWeightProducer(const edm::ParameterSet& pset)
 
   if ( weightingMethod_ == WeightingMethod::NVertex )
   {
-    std::cerr << "!!PileupWeightProducer!! We are using NON STANDARD method for the pileup reweight.\n"
+    std::cerr << "!!CATPileupWeightProducer!! We are using NON STANDARD method for the pileup reweight.\n"
               << "                         This weight values are directly from reco vertex\n";
     vertexToken_ = consumes<reco::VertexCollection>(pset.getParameter<edm::InputTag>("vertex"));
     simpleWeights_ = pset.getParameter<std::vector<double> >("simpleWeights");
@@ -103,7 +103,7 @@ PileupWeightProducer::PileupWeightProducer(const edm::ParameterSet& pset)
 
 }
 
-void PileupWeightProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
+void CATPileupWeightProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 {
   std::auto_ptr<int> nTrueIntr(new int(-1));
   std::auto_ptr<float> weight(new float(1.));
@@ -157,4 +157,4 @@ void PileupWeightProducer::produce(edm::Event& event, const edm::EventSetup& eve
   event.put(weightDn, "dn");
 }
 
-DEFINE_FWK_MODULE(PileupWeightProducer);
+DEFINE_FWK_MODULE(CATPileupWeightProducer);

--- a/CatProducer/python/pileupWeight_cff.py
+++ b/CatProducer/python/pileupWeight_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 #from   FWCore.PythonUtilities.LumiList import LumiList
 
-pileupWeight = cms.EDProducer("PileupWeightProducer",
+pileupWeight = cms.EDProducer("CATPileupWeightProducer",
     #weightingMethod = cms.string("NVertex"), # Simple bin-by-bin correction of nVertex distribution. Non standard
     weightingMethod = cms.string("Standard"), # The Standard method in the CMSSW
     #weightingMethod = cms.string("RedoWeight"), # this is to be used re-reweight on CATTuple


### PR DESCRIPTION
Redo the pileup weights on the fly to solve the wrong pileup weight(down) input issue #561
run_TtbarDileptonAnalyzer_cfg.py and run_TtbarBbbarDileptonAnalyzer_cfg.py are modified to redo the pu weighs in this PR.
