### PR TITLE
added jet quark/gluon likelihood (AK4 jets). Fat jets (AK8)

### DIFF
--- a/CatProducer/plugins/CATFatJetProducer.cc
+++ b/CatProducer/plugins/CATFatJetProducer.cc
@@ -1,3 +1,8 @@
+//
+// Extended for jet subtructure analysis
+// Created by Suyong Choi
+// Modified: 2016/09/22
+//
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -11,7 +16,7 @@
 #include "DataFormats/Common/interface/RefToPtr.h"
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
-#include "CATTools/DataFormats/interface/Jet.h"
+#include "CATTools/DataFormats/interface/FatJet.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
@@ -29,10 +34,10 @@ using namespace std;
 
 namespace cat {
 
-  class CATJetProducer : public edm::stream::EDProducer<> {
+  class CATFatJetProducer : public edm::stream::EDProducer<> {
   public:
-    explicit CATJetProducer(const edm::ParameterSet & iConfig);
-    virtual ~CATJetProducer() { }
+    explicit CATFatJetProducer(const edm::ParameterSet & iConfig);
+    virtual ~CATFatJetProducer() { }
 
     void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&) override;
@@ -48,10 +53,9 @@ namespace cat {
   private:
     edm::EDGetTokenT<pat::JetCollection> src_;
     edm::EDGetTokenT<double> rhoToken_;
-    edm::EDGetTokenT<edm::ValueMap<float>> qgToken_;
 
     const std::vector<std::string> btagNames_;
-    std::string uncertaintyTag_, payloadName_, jetalgoName_;
+    std::string uncertaintyTag_, payloadName_;
     const std::string jetResFilePath_, jetResSFFilePath_;
     bool setGenParticle_;
     bool runOnMC_;
@@ -63,7 +67,7 @@ namespace cat {
 
 } // namespace
 
-cat::CATJetProducer::CATJetProducer(const edm::ParameterSet & iConfig) :
+cat::CATFatJetProducer::CATFatJetProducer(const edm::ParameterSet & iConfig) :
   src_(consumes<pat::JetCollection>(iConfig.getParameter<edm::InputTag>("src"))),
   rhoToken_(consumes<double>(iConfig.getParameter<edm::InputTag>("rho"))),
   btagNames_(iConfig.getParameter<std::vector<std::string> >("btagNames")),
@@ -72,19 +76,17 @@ cat::CATJetProducer::CATJetProducer(const edm::ParameterSet & iConfig) :
   jetResSFFilePath_(edm::FileInPath(iConfig.getParameter<std::string>("jetResSFFile")).fullPath()),
   setGenParticle_(iConfig.getParameter<bool>("setGenParticle"))
 {
-    qgToken_ = consumes<edm::ValueMap<float>>(edm::InputTag("QGTagger", "qgLikelihood"));
-    jetalgoName_ = iConfig.getParameter<edm::InputTag>("src").label();
-    std::cout << "Jet algo name " << jetalgoName_ << std::endl;
-    produces<std::vector<cat::Jet> >();
+  produces<std::vector<cat::FatJet> >();
+  ///  pfjetIDFunctor = PFJetIDSelectionFunctor(PFJetIDSelectionFunctor::FIRSTDATA,PFJetIDSelectionFunctor::LOOSE);
 }
 
-void cat::CATJetProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&)
+void cat::CATFatJetProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup&)
 {
   edm::Service<edm::RandomNumberGenerator> rng;
   rng_ = &rng->getEngine(lumi.index());
 }
 
-void cat::CATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void cat::CATFatJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
 
   runOnMC_ = !iEvent.isRealData();
 
@@ -110,20 +112,10 @@ void cat::CATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   iEvent.getByToken(rhoToken_, rhoHandle);
   const double rho = *rhoHandle;
 
-  // for quark gluon likelihood calculation
-  edm::Handle<edm::ValueMap<float>> qgHandle; 
-  iEvent.getByToken(qgToken_, qgHandle);
+  auto_ptr<vector<cat::FatJet> >  out(new vector<cat::FatJet>());
+  for (const pat::Jet &aPatJet : *src) {
 
-  auto_ptr<vector<cat::Jet> >  out(new vector<cat::Jet>());
-
-  int ij=0;
-  for (auto aPatJetPointer = src->begin(); aPatJetPointer != src->end(); aPatJetPointer++)
-///  for (const pat::Jet &aPatJet : *src) 
-  {
-
-    const pat::Jet aPatJet = *aPatJetPointer;
-
-    cat::Jet aJet(aPatJet);
+    cat::FatJet aJet(aPatJet);
 
     ///https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID
     float NHF = aPatJet.neutralHadronEnergyFraction();
@@ -181,20 +173,6 @@ void cat::CATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
     int partonPdgId = aPatJet.genParton() ? aPatJet.genParton()->pdgId() : 0;
     aJet.setPartonPdgId(partonPdgId);
 
-    // calculate quark/gluon likelihood but only for AK4
-
-    if (jetalgoName_=="updatedPatJets")
-    {
-        edm::RefToBase<pat::Jet> jetRef(edm::Ref<pat::JetCollection>(src, aPatJetPointer - src->begin()));
-        float qgLikelihood = (*qgHandle)[jetRef];
-        aJet.setQGLikelihood(qgLikelihood);
-        //aJet.setQGLikelihood(aPatJet.userFloat("QGTaggerAK4PFCHS:qgLikelihood"));
-    }
-    else // for others, it's undefined
-    {
-        aJet.setQGLikelihood(-2.0);
-    }
-
     // setting JEC uncertainty
     if (!payloadName_.empty()){
       jecUnc->setJetEta(aJet.eta());
@@ -244,11 +222,34 @@ void cat::CATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
 
         aJet.setJER(fJER, fJERDn, fJERUp);
       }
-    }
+    } // for MC
 
+    // Jet substructure stuff
+    double tau1 = aPatJet.userFloat("NjettinessAK8:tau1");    //
+    double tau2 = aPatJet.userFloat("NjettinessAK8:tau2");    //  Access the n-subjettiness variables
+    double tau3 = aPatJet.userFloat("NjettinessAK8:tau3");    // 
+
+    double softdrop_mass = aPatJet.userFloat("ak8PFJetsCHSSoftDropMass"); // access to soft drop mass
+    double pruned_mass = aPatJet.userFloat("ak8PFJetsCHSPrunedMass");     // access to pruned mass
+
+    double puppi_pt    = aPatJet.userFloat("ak8PFJetsPuppiValueMap:pt");
+    double puppi_mass  = aPatJet.userFloat("ak8PFJetsPuppiValueMap:mass");
+    double puppi_eta   = aPatJet.userFloat("ak8PFJetsPuppiValueMap:eta");
+    double puppi_phi   = aPatJet.userFloat("ak8PFJetsPuppiValueMap:phi");
+    double puppi_tau1  = aPatJet.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1");
+    double puppi_tau2  = aPatJet.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2");
+    double puppi_tau3  = aPatJet.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3");
+
+    // set
+    aJet.set_taus(tau1, tau2, tau3);
+    aJet.set_prunedmass(pruned_mass);
+    aJet.set_softdropmass(softdrop_mass);
+    aJet.set_puppijet( puppi_pt, puppi_eta, puppi_phi, puppi_mass);
+    aJet.set_puppijettaus(puppi_tau1, puppi_tau2, puppi_tau3);
+
+    //
     out->push_back(aJet);
-    ij++;
-  }
+  } // loop over jets
 
   if (jecUnc) delete jecUnc;
 
@@ -257,4 +258,4 @@ void cat::CATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 using namespace cat;
-DEFINE_FWK_MODULE(CATJetProducer);
+DEFINE_FWK_MODULE(CATFatJetProducer);

--- a/CatProducer/python/catCandidates_cff.py
+++ b/CatProducer/python/catCandidates_cff.py
@@ -4,6 +4,7 @@ from CATTools.CatProducer.muonProducer_cfi import *
 from CATTools.CatProducer.electronProducer_cfi import *
 from CATTools.CatProducer.photonProducer_cfi import *
 from CATTools.CatProducer.jetProducer_cfi import *
+from CATTools.CatProducer.fatjetProducer_cfi import *
 from CATTools.CatProducer.metProducer_cfi import *
 from CATTools.CatProducer.tauProducer_cfi import *
 from CATTools.CatProducer.secondaryVertexProducer_cfi import *

--- a/CatProducer/python/catEventContent_cff.py
+++ b/CatProducer/python/catEventContent_cff.py
@@ -16,6 +16,7 @@ catEventContent.extend([
     'keep *_catPhotons_*_*',
     #'keep *_catTaus_*_*', 
     'keep *_catJets*_*_*',
+    'keep *_catFatJets*_*_*',
     'keep *_catMETs*_*_*',
     'keep *_catVertex_*_*',
     'keep *_catTrigger_*_*',

--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -3,6 +3,8 @@ import catDefinitions_cfi as cat
 import os
 print os.environ['CMSSW_BASE']
 
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
 def catTool(process, runOnMC=True, useMiniAOD=True):
     if runOnMC:
         from CATTools.CatProducer.pileupWeight_cff import pileupWeightMap
@@ -81,6 +83,32 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         ## process.particleFlowNoMuonPUPPI.candName         = 'packedPFCandidatesWoMuon'
         ## process.particleFlowNoMuonPUPPI.vertexName       = 'offlineSlimmedPrimaryVertices'
         
+        ########################################################################
+        ## Setup to acess quark/gluon likelihood value
+
+        #from JMEAnalysis.JetToolbox.jetToolbox_cff import jetToolbox
+        #jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', PUMethod='CHS', updateCollection='slimmedJets',  JETCorrPayload='AK8PFchs', miniAOD=True, addQGTagger=True )   ### For example
+        #jetToolbox( process, 'ak4', 'ak4JetSubs', 'out', PUMethod='CHS', miniAOD=True, addQGTagger=True )   ### For example
+
+#process.options.allowUnscheduled = cms.untracked.bool(True)
+        qgDatabaseVersion = 'v1' # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+        QGPoolDBESSource = cms.ESSource("PoolDBESSource",
+                CondDBSetup,
+                toGet = cms.VPSet(),
+                connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
+        )
+
+        for type in ['AK4PFchs','AK4PFchs_antib']:
+            QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
+                record = cms.string('QGLikelihoodRcd'),
+                tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
+                label  = cms.untracked.string('QGL_'+type)
+           )))
+        process.load('RecoJets.JetProducers.QGTagger_cfi')
+        process.QGTagger.srcJets    = cms.InputTag("updatedPatJets")   # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
+        #process.QGTagger.srcJets    = cms.InputTag("slimmedJets")   # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
+        #process.QGTagger.srcJets    = cms.InputTag("selectedPatJetsAK4PFCHS")   # Could be reco::PFJetCollection or pat::JetCollection (both AOD and miniAOD)
+        process.QGTagger.jetsLabel  = cms.string('QGL_AK4PFchs')        # Other options: see https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
         #######################################################################
         ## applying new jec on the fly
         process.load("PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff")
@@ -115,10 +143,15 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
             engineName = cms.untracked.string('TRandom3'),
             initialSeed = cms.untracked.uint32(1),
         )
+        process.RandomNumberGeneratorService.catFatJets = cms.PSet(
+            engineName = cms.untracked.string('TRandom3'),
+            initialSeed = cms.untracked.uint32(1),
+        )
         process.RandomNumberGeneratorService.catJetsPuppi = cms.PSet(
             engineName = cms.untracked.string('TRandom3'),
             initialSeed = cms.untracked.uint32(1),
         )
+
         ## #######################################################################
         ## # MET corrections from https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription
         #from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD

--- a/CatProducer/python/fatjetProducer_cfi.py
+++ b/CatProducer/python/fatjetProducer_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+catFatJets = cms.EDProducer('CATFatJetProducer',
+    src = cms.InputTag('slimmedJetsAK8'),
+    rho = cms.InputTag('fixedGridRhoFastjetAll'),
+    btagNames = cms.vstring('pfCombinedInclusiveSecondaryVertexV2BJetTags','pfCombinedMVAV2BJetTags',"inclusiveCandidateSecondaryVerticesCvsL","pfCombinedCvsLJetTags","pfCombinedCvsBJetTags"),
+    payloadName = cms.string('AK8PFchs'),
+    jetResFile   = cms.string("CATTools/CatProducer/data/JER/Spring16_25nsV6_MC_PtResolution_AK8PFchs.txt"),
+    jetResSFFile = cms.string("CATTools/CatProducer/data/JER/Spring16_25nsV6_MC_SF_AK8PFchs.txt"),
+    setGenParticle = cms.bool(False),
+)
+
+#There is a CMS rule that we are supposed to use one module per cfi file.  

--- a/DataFormats/interface/FatJet.h
+++ b/DataFormats/interface/FatJet.h
@@ -1,0 +1,63 @@
+#ifndef CATTools_FatJet_H
+#define CATTools_FatJet_H
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "CATTools/DataFormats/interface/Particle.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/JetCorrFactors.h"
+#include "CATTools/DataFormats/interface/Jet.h"
+
+#include <string>
+#include <boost/array.hpp>
+
+// Define typedefs for convenience
+namespace cat {
+    class FatJet;
+    typedef std::vector<FatJet>              FatJetCollection;
+    typedef edm::Ref<FatJetCollection>       FatJetRef;
+    typedef edm::RefVector<FatJetCollection> FatJetRefVector;
+}
+
+namespace cat {
+
+  class FatJet : public Jet {
+  public:
+    FatJet();
+    FatJet(const reco::LeafCandidate & aJet);
+    virtual ~FatJet();
+
+	// accessing variables for jet substructure
+	float tau1() const { return tau1_; }
+	float tau2() const { return tau2_; }
+	float tau3() const { return tau3_; }
+	float prunedmass() const { return prunedMass_; }
+	float softdropmass() const { return softdropMass_; }
+	float puppi_pt() const { return puppi_pt_; }
+	float puppi_eta() const { return puppi_eta_; }
+	float puppi_phi() const { return puppi_phi_; }
+	float puppi_mass() const { return puppi_mass_; }
+	float puppi_tau1() const { return puppi_tau1_; }
+	float puppi_tau2() const { return puppi_tau2_; }
+	float puppi_tau3() const { return puppi_tau3_; }
+
+	void set_taus(float f1, float f2, float f3) { tau1_ = f1; tau2_ = f2; tau3_ = f3; }
+	void set_prunedmass(float f) { prunedMass_ = f; }
+	void set_softdropmass(float f) { softdropMass_ = f;}
+	void set_puppijet(float fpt, float feta, float fphi, float fm) { puppi_pt_ = fpt; puppi_eta_ = feta; puppi_phi_ = fphi, puppi_mass_ = fm; }
+	void set_puppijettaus(float f1, float f2, float f3) { puppi_tau1_ = f1; puppi_tau2_ = f2; puppi_tau3_ = f3; }
+
+  private:
+
+	// Additional variables for fat jets
+	float tau1_, tau2_, tau3_;
+	float prunedMass_;
+	float softdropMass_;
+
+	// associated puppi jet info
+	float puppi_pt_, puppi_eta_, puppi_phi_, puppi_mass_;
+	float puppi_tau1_, puppi_tau2_, puppi_tau3_;
+  };
+}
+
+#endif

--- a/DataFormats/interface/Jet.h
+++ b/DataFormats/interface/Jet.h
@@ -91,6 +91,7 @@ namespace cat {
     float smearedResUp(int era = 0) const { return smearedRes(+1, era); };
     float smearedResDown(int era = 0) const { return smearedRes(-1, era); };
 
+    float qgLikelihood() const { return qgLikelihood_; }
     
     void setLooseJetID(bool id) { looseJetID_ = id; }
     void setTightJetID(bool id) { tightJetID_ = id; }
@@ -121,6 +122,8 @@ namespace cat {
       fJER_ = fJER; fJERUp_ = fJERUp; fJERDown_ = fJERDown;
     }
 
+    void setQGLikelihood(float f) { qgLikelihood_ = f; }
+
   private:
 
     edm::FwdRef<reco::GenJetCollection>  genJetFwdRef_;
@@ -150,6 +153,8 @@ namespace cat {
     float shiftedEnUp_;
 
     float fJER_, fJERUp_, fJERDown_;
+
+    float qgLikelihood_;
 
   };
 }

--- a/DataFormats/src/FatJet.cc
+++ b/DataFormats/src/FatJet.cc
@@ -1,0 +1,33 @@
+#include "CATTools/DataFormats/interface/FatJet.h"
+#include <unordered_map>
+#include <algorithm>
+
+using namespace cat;
+
+/// default constructor
+FatJet::FatJet():
+    Jet(),
+    tau1_(-1), tau2_(-1), tau3_(-1),
+    prunedMass_(0), softdropMass_(0),
+    puppi_pt_(0), 
+    puppi_eta_(0), 
+    puppi_phi_(0), 
+    puppi_mass_(0),
+    puppi_tau1_(-1), puppi_tau2_(-1), puppi_tau3_(-1)
+{
+}
+
+FatJet::FatJet(const reco::LeafCandidate & aJet) :
+  Jet( aJet ),
+    tau1_(-1), tau2_(-1), tau3_(-1),
+    prunedMass_(0), softdropMass_(0),
+    puppi_pt_(0), 
+    puppi_eta_(0), 
+    puppi_phi_(0), 
+    puppi_mass_(0),
+    puppi_tau1_(-1), puppi_tau2_(-1), puppi_tau3_(-1)
+{}
+
+/// destructor
+FatJet::~FatJet() {
+}


### PR DESCRIPTION
- Added quark/gluon likelihood variable and method for accessing it (only available for AK4 jets)
- Added FatJet class derived from Jet class. FatJet has several variables (N-subjettiness, pruned mass, soft drop mass, etc) that are not available in the Jet class. FatJet is intended to be used with AK8 jets.
- The python configs are updated to reflect these.
