### PR TITLE
Missing dictionary FatJet

### DIFF
--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -8,6 +8,7 @@
 #include "CATTools/DataFormats/interface/Jet.h"
 #include "CATTools/DataFormats/interface/Tau.h"
 #include "CATTools/DataFormats/interface/MET.h"
+#include "CATTools/DataFormats/interface/FatJet.h"
 #include "CATTools/DataFormats/interface/GenJet.h"
 #include "CATTools/DataFormats/interface/GenTop.h"
 #include "CATTools/DataFormats/interface/MCParticle.h"
@@ -80,6 +81,12 @@ namespace {
     edm::Wrapper<cat::MET> metw;
     edm::Wrapper<std::vector<cat::MET> > metvw;
     edm::Ptr<cat::MET> metPtr;
+
+    cat::FatJet fj_;
+    std::vector<cat::FatJet> fjv;
+    edm::Wrapper<cat::FatJet> fjw;
+    edm::Wrapper<std::vector<cat::FatJet> > fjvw;
+    edm::Ptr<cat::FatJet> fjPtr;
 
     cat::MCParticle ma_;
     std::vector<cat::MCParticle> mav;

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -58,6 +58,12 @@
   <class name="edm::Wrapper<std::vector<cat::MCParticle> >"/>
   <class name="edm::Ptr<cat::MCParticle>"/>
 
+  <class name="cat::FatJet"/>
+  <class name="std::vector<cat::FatJet>"/>
+  <class name="edm::Wrapper<cat::FatJet>"/>
+  <class name="edm::Wrapper<std::vector<cat::FatJet> >"/>
+  <class name="edm::Ptr<cat::FatJet>"/>
+
   <class name="cat::GenJet"/>
   <class name="std::vector<cat::GenJet>"/>
   <class name="edm::Wrapper<cat::GenJet>"/>


### PR DESCRIPTION
FatJet was missing in the classDef, was necessary to run PAT2CAT.
@jshlee , was it successful without this fix?