### PR TITLE
Keep Electron/Photon smearing factors, 80X VID on the fly

### DIFF
--- a/CatProducer/python/EGamma/smearing_cff.py
+++ b/CatProducer/python/EGamma/smearing_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+## Energy smearing and scale correction
+## https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer
+
+def enableElectronSmearing(process, runOnMC=True):
+    process.load('EgammaAnalysis.ElectronTools.calibratedElectronsRun2_cfi')
+
+    process.RandomNumberGeneratorService.calibratedPatElectrons = cms.PSet(
+        initialSeed = cms.untracked.uint32(81),
+        engineName = cms.untracked.string('TRandom3')
+    )
+
+    process.calibratedPatElectrons.isMC = runOnMC
+    process.catElectrons.src = "calibratedPatElectrons"
+
+    return process
+
+def enablePhotonSmearing(process, runOnMC=True):
+    process.load('EgammaAnalysis.ElectronTools.calibratedPhotonsRun2_cfi')
+
+    process.RandomNumberGeneratorService.calibratedPatPhotons = cms.PSet(
+        initialSeed = cms.untracked.uint32(81),
+        engineName = cms.untracked.string('TRandom3')
+    )
+
+    process.calibratedPatPhotons.isMC = runOnMC
+    process.catPhotons.src = "calibratedPatPhotons"
+
+    return process
+

--- a/CatProducer/python/EGamma/versionnedID_cff.py
+++ b/CatProducer/python/EGamma/versionnedID_cff.py
@@ -1,0 +1,65 @@
+import FWCore.ParameterSet.Config as cms
+
+## for egamma pid https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_for_8_0
+def enableElectronVID(process):
+    from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDElectronIdProducer, DataFormat, setupAllVIDIdsInModule, setupVIDElectronSelection
+    switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
+
+    electron_ids = [
+        'cutBasedElectronHLTPreselecition_Summer16_V1_cff',
+        'cutBasedElectronID_Summer16_80X_V1_cff',
+        'heepElectronID_HEEPV60_cff',
+        'mvaElectronID_Spring15_25ns_Trig_V1_cff',
+        'mvaElectronID_Spring15_25ns_nonTrig_V1_cff',
+    ]
+    for idmod in electron_ids:
+        idmod = "RecoEgamma.ElectronIdentification.Identification."+idmod
+        setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+
+    electron_idNames = [
+        "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto",
+        "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose",
+        "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium",
+        "egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight",
+        "egmGsfElectronIDs:cutBasedElectronHLTPreselection-Summer16-V1",
+        "egmGsfElectronIDs:heepElectronID-HEEPV60",
+        "egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80",
+        "egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp90",
+        "egmGsfElectronIDs:mvaEleID-Spring15-25ns-Trig-V1-wp90",
+        "egmGsfElectronIDs:mvaEleID-Spring15-25ns-Trig-V1-wp80",
+    ]
+    process.catElectrons.electronIDSources = cms.PSet()
+    for idName in electron_idNames:
+        setattr(process.catElectrons.electronIDSources,
+                idName.split(':')[-1].replace('-','_'),
+                cms.InputTag(idName))
+
+    return process
+
+def enablePhotonVID(process):
+    from PhysicsTools.SelectorUtils.tools.vid_id_tools import switchOnVIDPhotonIdProducer, DataFormat, setupAllVIDIdsInModule, setupVIDPhotonSelection
+    switchOnVIDPhotonIdProducer(process, DataFormat.MiniAOD)
+
+    #Use IDs from https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/RecoEgamma/PhotonIdentification/python/Identification/ 
+    photon_ids = [
+        'cutBasedPhotonID_Spring15_25ns_V1_cff',
+        'mvaPhotonID_Spring15_25ns_nonTrig_V2_cff',
+    ]
+    for idmod in photon_ids:
+        idmod = 'RecoEgamma.PhotonIdentification.Identification.'+idmod
+        setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
+
+    photon_idNames = [
+        "egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-loose",
+        "egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-medium",
+        "egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-tight",
+        "egmPhotonIDs:mvaPhoID-Spring15-25ns-nonTrig-V2-wp90",
+    ]
+    process.catPhotons.photonIDSources = cms.PSet()
+    for idName in photon_idNames:
+        setattr(process.catPhotons.photonIDSources,
+                idName.split(':')[-1].replace('-','_'),
+                cms.InputTag(idName))
+
+    return process
+

--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -153,64 +153,15 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         #process.catMETsNoHF = process.catMETs.clone(src = cms.InputTag("slimmedMETsNoHF","","CAT"))
         #del process.slimmedMETsNoHF.caloMET        
         #######################################################################
-        ## Energy smearing and scale correction
-        ## https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer
-        process.RandomNumberGeneratorService.calibratedPatElectrons = cms.PSet(
-            initialSeed = cms.untracked.uint32(81),
-            engineName = cms.untracked.string('TRandom3')
-        )
-        process.RandomNumberGeneratorService.calibratedPatPhotons = cms.PSet(
-            initialSeed = cms.untracked.uint32(81),
-            engineName = cms.untracked.string('TRandom3')
-        )
-        process.load('EgammaAnalysis.ElectronTools.calibratedElectronsRun2_cfi')
-        process.calibratedPatElectrons.isMC = runOnMC
-        process.catElectrons.src = "calibratedPatElectrons"
-    
-        process.load('EgammaAnalysis.ElectronTools.calibratedPhotonsRun2_cfi')
-        process.calibratedPatPhotons.isMC = runOnMC
-        process.catPhotons.src = "calibratedPatPhotons"
-        #######################################################################
-        ## for egamma pid https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_for_74X
-        ##from PhysicsTools.SelectorUtils.tools.vid_id_tools import DataFormat,switchOnVIDPhotonIdProducer,setupAllVIDIdsInModule,setupVIDPhotonSelection            
-        ##switchOnVIDPhotonIdProducer(process, DataFormat.MiniAOD)
-
-        #Use IDs from https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/RecoEgamma/PhotonIdentification/python/Identification/ 
-        ##photon_ids = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring15_25ns_V1_cff',
-        ##              'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V2_cff']
+        ## Energy/Photon smearing and scale correction
+        from CATTools.CatProducer.EGamma.smearing_cff import enableElectronSmearing, enablePhotonSmearing
+        enableElectronSmearing(process, runOnMC)
+        enablePhotonSmearing(process, runOnMC)
         
-        #add them to the VID producer
-        ##for idmod in photon_ids:
-        ##    setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
-
-        ##process.catPhotons.photonIDSources = cms.PSet( 
-        ##    cutBasedPhotonID_Spring15_25ns_V1_standalone_loose = cms.InputTag("egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-loose"),
-        ##    cutBasedPhotonID_Spring15_25ns_V1_standalone_medium = cms.InputTag("egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-medium"),
-        ##    cutBasedPhotonID_Spring15_25ns_V1_standalone_tight = cms.InputTag("egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-tight"),
-        ##    mvaPhoID_Spring15_25ns_nonTrig_V2_wp90 =  cms.InputTag("egmPhotonIDs:mvaPhoID-Spring15-25ns-nonTrig-V2-wp90"),
-        ##    )
-        
-        ## from PhysicsTools.SelectorUtils.tools.vid_id_tools import DataFormat,switchOnVIDElectronIdProducer,setupAllVIDIdsInModule,setupVIDElectronSelection
-        ## electron_ids = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
-        ##                 'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
-        ##                 'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff',
-        ##                 'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_Trig_V1_cff']
-        ## switchOnVIDElectronIdProducer(process, DataFormat.MiniAOD)
-        ## for idmod in electron_ids:
-        ##     setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
-
-        ## process.catElectrons.electronIDSources = cms.PSet(
-        ##     cutBasedElectronID_Spring15_25ns_V1_standalone_loose = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-loose"),
-        ##     cutBasedElectronID_Spring15_25ns_V1_standalone_medium = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-medium"),
-        ##     cutBasedElectronID_Spring15_25ns_V1_standalone_tight = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-tight"),
-        ##     cutBasedElectronID_Spring15_25ns_V1_standalone_veto = cms.InputTag("egmGsfElectronIDs:cutBasedElectronID-Spring15-25ns-V1-standalone-veto"),
-        ##     heepElectronID_HEEPV60 = cms.InputTag("egmGsfElectronIDs:heepElectronID-HEEPV60"),
-        ##     mvaEleID_Spring15_25ns_nonTrig_V1_wp80 = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80"),
-        ##     mvaEleID_Spring15_25ns_nonTrig_V1_wp90 = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp90"),
-        ##     mvaEleID_Spring15_25ns_Trig_V1_wp80 = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-Trig-V1-wp90"),
-        ##     mvaEleID_Spring15_25ns_Trig_V1_wp90 = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-Trig-V1-wp80"),
-        ## )
-
+        ## Electron/Photon VID
+        from CATTools.CatProducer.EGamma.versionnedID_cff import enableElectronVID, enablePhotonVID
+        enableElectronVID(process)
+        enablePhotonVID(process)
        
         #######################################################################    
         # adding pfMVAMet https://twiki.cern.ch/twiki/bin/viewauth/CMS/MVAMet#Spring15_samples_with_25ns_50ns

--- a/CatProducer/python/electronProducer_cfi.py
+++ b/CatProducer/python/electronProducer_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 catElectrons = cms.EDProducer("CATElectronProducer",
     src = cms.InputTag("slimmedElectrons"),
+    unsmaredElectrons = cms.InputTag("slimmedElectrons"),
     mcLabel = cms.InputTag("prunedGenParticles"),
     vertexLabel = cms.InputTag('catVertex'),
     beamLineSrc = cms.InputTag("offlineBeamSpot"),

--- a/CatProducer/python/photonProducer_cfi.py
+++ b/CatProducer/python/photonProducer_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 catPhotons = cms.EDProducer("CATPhotonProducer",
     src = cms.InputTag("slimmedPhotons"),
+    unsmearedPhotons = cms.InputTag("slimmedPhotons"),
     photonIDs = cms.vstring("cutBasedPhotonID-Spring15-25ns-V1-standalone-loose",
                             "cutBasedPhotonID-Spring15-25ns-V1-standalone-medium",
                             "cutBasedPhotonID-Spring15-25ns-V1-standalone-tight",

--- a/CatProducer/test/runtests.sh
+++ b/CatProducer/test/runtests.sh
@@ -4,16 +4,16 @@ function die { echo $1: status $2 ;  exit $2; }
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runOnRelVal=0' \
-  'inputFiles=/store/mc/RunIISpring16MiniAODv2/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/10000/FE6A91CD-7F25-E611-92EC-001E0B1C74DA.root' \
+  'inputFiles=/store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/00000/004A0552-3929-E611-BD44-0025905A48F0.root' \
   || die 'Failure to run PAT2CAT from MiniAODSIM' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'runOnRelVal=1' \
-  'inputFiles=/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/50000/FEBA3849-3F2A-E611-BADD-0025905B856C.root' \
+  'inputFiles=/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/50000/000FF6AC-9F2A-E611-A063-0CC47A4C8EB0.root' \
   || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=0' 'useMiniAOD=1' \
-  'inputFiles= /store/data/Run2016B/DoubleMuon/MINIAOD/PromptReco-v2/000/274/442/00000/0496E479-DD2D-E611-81D3-02163E0144B6.root' \
+  'inputFiles=/store/data/Run2016B/SingleMuon/MINIAOD/PromptReco-v2/000/275/375/00000/FEDDBC5C-4339-E611-8740-02163E0136C4.root' \
   || die 'Failure to run PAT2CAT from MiniAOD real data' $?
 

--- a/DataFormats/interface/Electron.h
+++ b/DataFormats/interface/Electron.h
@@ -41,7 +41,7 @@ namespace cat {
 
     float ipsignificance() const { return ipsig_;}
 
-    
+    float smearedScale() const { return smearedScale_; }
     float shiftedEn() const { if (this->isEB()) return 0.006; else return 0.015; }
     float shiftedEnDown() const {return 1-shiftedEn();}
     float shiftedEnUp() const {return  1+shiftedEn();}
@@ -67,6 +67,7 @@ namespace cat {
     void setTrigMVAValid(bool val) { isTrigMVAValid_ = val; }
     void setIpSignficance(float ipsig) {ipsig_ = ipsig;}
 
+    void setSmearedScale(const float scale) { smearedScale_ = scale; }
 
     float scaleFactor(const std::string& name, int sign = 0) const;
     
@@ -74,6 +75,7 @@ namespace cat {
 
     std::vector<pat::Electron::IdPair> electronIDs_;
 
+    float smearedScale_; // smearedScale = (pt_smeared)/(pt_original). Undo smearing by pt()/smearedScale()
     float relIso03_;
     float relIso04_;
     float ipsig_;

--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -59,6 +59,8 @@ namespace cat {
     float SCRawEnergy() const { return scRawE_;}
     float SCPreShowerEnergy() const { return scPreShE_;}
 
+    float smearedScale() const { return smearedScale_; }
+
     bool mcMatched() const { return mcMatched_; }
 
     float getEffArea(IsoType iso_type, float scEta) ;
@@ -94,8 +96,9 @@ namespace cat {
     void setSCrawEnergy(float raw_e){ scRawE_ = raw_e;}
     void setSCPreShowerEnergy(float pre_E){ scPreShE_ = pre_E;}
 
-    void setMCMatched(bool m) { mcMatched_ = m; }
+    void setSmearedScale(const float scale) { smearedScale_ = scale; }
 
+    void setMCMatched(bool m) { mcMatched_ = m; }
     
   private:
 
@@ -121,6 +124,8 @@ namespace cat {
     float r9_;
     float HoverE_;
     float scEta_, scPhi_, scRawE_, scPreShE_;
+
+    float smearedScale_;
 
     bool mcMatched_;
     

--- a/DataFormats/src/Electron.cc
+++ b/DataFormats/src/Electron.cc
@@ -8,6 +8,7 @@ Electron::Electron() {
 
 Electron::Electron(const reco::LeafCandidate & aElectron) :
   Lepton( aElectron ),
+  smearedScale_(1),
   relIso03_(0),
   relIso04_(0),
   ipsig_(0),

--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -24,6 +24,7 @@ Photon::Photon(const reco::LeafCandidate & aPhoton) :
   r9_(0),
   HoverE_(0),
   scEta_(0), scPhi_(0), scRawE_(0), scPreShE_(0),
+  smearedScale_(1),
   mcMatched_(false)
 {}
 


### PR DESCRIPTION
**Problems**:

- Due to the randomness feature of electron smearing, synchronization exercise was not trivial. pT before smearing had to be kept.
- VID-on-the-fly does not work if electron smearing is enabled since VID accepts reference to the original electron collection.

**Solution**:

- Keep smearing factor, (smeared_pt)/(original_pt). pt() of catElectron is AFTER SMEARING. One can recover original pt by dividing catElectron.smearedScale().
- Modified CatElectronProducer to take VID result from the original collection.

**Other changes**:

- Electron ID names are updated to follow post-ICHEP16 recipe. https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_for_8_0
```
    egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-veto
    egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-loose
    egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-medium
    egmGsfElectronIDs:cutBasedElectronID-Summer16-80X-V1-tight
    egmGsfElectronIDs:cutBasedElectronHLTPreselection-Summer16-V1
```
- Fixed path to runtests root files.

**This PR introduces DataFormat changes, there can be compatibility issue.**