### PR TITLE
CATTrigger dataformat

### DIFF
--- a/CatProducer/python/producers/triggerProducer_cfi.py
+++ b/CatProducer/python/producers/triggerProducer_cfi.py
@@ -1,28 +1,42 @@
 import FWCore.ParameterSet.Config as cms
 
 catTrigger = cms.EDProducer("CATTriggerProducer",
-    triggerBits = cms.VInputTag(
-        cms.InputTag("TriggerResults","","HLT2"),# due to reHLT, this is the first choice
-        cms.InputTag("TriggerResults","","HLT"),# if above is not found, falls to default
+    HLT = cms.PSet(
+        triggerResults = cms.VInputTag(
+            cms.InputTag("TriggerResults","","HLT2"),# due to reHLT, this is the first choice
+            cms.InputTag("TriggerResults","","HLT"),# if above is not found, falls to default
+        ),
+        objects = cms.InputTag("selectedPatTrigger"),
+        prescales = cms.InputTag("patTrigger"),
+        select = cms.vstring(
+            "HLT_Ele", "HLT_DoubleEle", 
+            "HLT_Mu", "HLT_TkMu", "HLT_IsoMu", "HLT_IsoTkMu", 
+            "HLT_DiMu", "HLT_DoubleIsoMu",
+            "HLT_PFJet",
+            "HLT_DoublePhoton", "HLT_Photon"
+        ),
     ),
-    metFilterBits = cms.VInputTag(
-        cms.InputTag("TriggerResults","","PAT"),
-        cms.InputTag("TriggerResults","","RECO"),
+
+    Flag = cms.PSet(
+        Flags = cms.VInputTag(
+            ## Keep TriggerResults with prefix "Flag_"
+            cms.InputTag("TriggerResults","","PAT"),
+            cms.InputTag("TriggerResults","","RECO"),
+        ),
+        bools = cms.VInputTag(
+            ## Keep EDProducer output with boolean type (Flag_ will be added in the front of the names)
+            cms.InputTag("BadChargedCandidateFilter"),
+            cms.InputTag("BadPFMuonFilter"),
+        ),
+        names = cms.vstring(
+            ## Flags to keep
+            "HBHENoiseFilter", "HBHENoiseIsoFilter",
+            "BadPFMuonFilter", "BadChargedCandidateFilter",
+            "EcalDeadCellTriggerPrimitiveFilter",
+            "goodVertices",
+            "eeBadScFilter",
+            "globalTightHalo2016Filter",
+        ),
     ),
-    triggerObjects = cms.InputTag("selectedPatTrigger"),
-    triggerPrescales = cms.InputTag("patTrigger"),
-    selectTrigObjects = cms.vstring("HLT_Ele", "HLT_DoubleEle", "HLT_Mu", "HLT_TkMu", "HLT_IsoMu", "HLT_IsoTkMu", "HLT_DiMu", "HLT_DoubleIsoMu", "HLT_PFJet","HLT_DoublePhoton", "HLT_Photon"),
-    metFilterNames = cms.vstring(),
-    hltPathNames = cms.vstring(),
-##     metFilterNames = cms.vstring(
-##     "HBHENoiseFilter",
-##     "CSCTightHaloFilter",
-##     "goodVertices",
-##     "eeBadScFilter",
-##     "EcalDeadCellTriggerPrimitiveFilter",
-##     ),
-##     hltPathNames = cms.vstring(
-##     "HLT_Mu17_Mu8_DZ_v*","HLT_Mu17_TkMu8_DZ_v*","HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_v*","HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v*","HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v*","HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v*","HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v*", "HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v*","HLT_Ele16_Ele12_Ele8_CaloIdL_TrackIdL_v*","HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ_v*","HLT_DoubleEle33_CaloIdL_GsfTrkIdVL_v*","HLT_Ele27_eta2p1_WPLoose_Gsf_TriCentralPFJet30_v*",
-## "HLT_Ele12_CaloIdL_TrackIdL_IsoVL_v*","HLT_Ele17_CaloIdL_TrackIdL_IsoVL_v*"
-##     ),
+
 )

--- a/DataFormats/src/classes.h
+++ b/DataFormats/src/classes.h
@@ -14,6 +14,7 @@
 #include "CATTools/DataFormats/interface/MCParticle.h"
 #include "CATTools/DataFormats/interface/SecVertex.h"
 #include "CATTools/DataFormats/interface/GenWeights.h"
+#include "CATTools/DataFormats/interface/TriggerBits.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 #include <vector>
@@ -123,6 +124,9 @@ namespace {
 
     cat::GenWeightInfo gwi;
     edm::Wrapper<cat::GenWeightInfo> wgwi;
+
+    cat::TriggerBits tb;
+    edm::Wrapper<cat::TriggerBits> wtb;
   };
 
 

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -94,4 +94,7 @@
 
   <class name="cat::GenWeightInfo" />
   <class name="edm::Wrapper<cat::GenWeightInfo>" />
+
+  <class name="cat::TriggerBits" />
+  <class name="edm::Wrapper<cat::TriggerBits>" />
 </lcgdict>


### PR DESCRIPTION
This PR introduces dataformat changes

**Motivation**
The CATTriggerProducer is originally designed to save trigger bits in boolean format, but this was not enabled by default. The original TriggerResults collection have been stored and used by analyzers.
Using TriggerResults is standard way to apply event filter, but it needs few lines of duplicated codes to initialize handle, loop over trigger names, matching, etc.
Also, there are trigger paths which are not interested in most analyses, highly prescaled or even disabled.
We can give more convenient interface to access trigger results (with prescale information as was in the original design) with compact data format.

