### PR TITLE
Acceptance cuts during production

### DIFF
--- a/CatProducer/plugins/CATFatJetProducer.cc
+++ b/CatProducer/plugins/CATFatJetProducer.cc
@@ -219,7 +219,7 @@ void cat::CATFatJetProducer::produce(edm::Event & iEvent, const edm::EventSetup 
     // Jet substructure stuff
     double tau1 = aPatJet.userFloat("NjettinessAK8:tau1");    //
     double tau2 = aPatJet.userFloat("NjettinessAK8:tau2");    //  Access the n-subjettiness variables
-    double tau3 = aPatJet.userFloat("NjettinessAK8:tau3");    // 
+    double tau3 = aPatJet.userFloat("NjettinessAK8:tau3");    //
 
     double softdrop_mass = aPatJet.userFloat("ak8PFJetsCHSSoftDropMass"); // access to soft drop mass
     double pruned_mass = aPatJet.userFloat("ak8PFJetsCHSPrunedMass");     // access to pruned mass

--- a/CatProducer/plugins/CATJetProducer.cc
+++ b/CatProducer/plugins/CATJetProducer.cc
@@ -55,6 +55,7 @@ namespace cat {
     const std::string jetResFilePath_, jetResSFFilePath_;
     bool setGenParticle_;
     bool runOnMC_;
+    const double minPt_, maxEta_;
     //PFJetIDSelectionFunctor pfjetIDFunctor;
     JetCorrectionUncertainty *jecUnc;
 
@@ -71,7 +72,9 @@ cat::CATJetProducer::CATJetProducer(const edm::ParameterSet & iConfig) :
   payloadName_(iConfig.getParameter<std::string>("payloadName")),
   jetResFilePath_(edm::FileInPath(iConfig.getParameter<std::string>("jetResFile")).fullPath()),
   jetResSFFilePath_(edm::FileInPath(iConfig.getParameter<std::string>("jetResSFFile")).fullPath()),
-  setGenParticle_(iConfig.getParameter<bool>("setGenParticle"))
+  setGenParticle_(iConfig.getParameter<bool>("setGenParticle")),
+  minPt_(iConfig.getParameter<double>("minPt")),
+  maxEta_(iConfig.getParameter<double>("maxEta"))
 {
 
   produces<std::vector<cat::Jet> >();
@@ -110,17 +113,19 @@ void cat::CATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
   const double rho = *rhoHandle;
 
   // for quark gluon likelihood calculation
-  edm::Handle<edm::ValueMap<float>> qgHandle; 
+  edm::Handle<edm::ValueMap<float>> qgHandle;
   iEvent.getByToken(qgToken_, qgHandle);
 
   auto_ptr<vector<cat::Jet> >  out(new vector<cat::Jet>());
 
   int ij=0;
   for (auto aPatJetPointer = src->begin(); aPatJetPointer != src->end(); aPatJetPointer++)
-///  for (const pat::Jet &aPatJet : *src) 
+///  for (const pat::Jet &aPatJet : *src)
   {
 
     const pat::Jet aPatJet = *aPatJetPointer;
+    if ( std::abs(aPatJet.eta()) > maxEta_ ) continue;
+    if ( aPatJet.pt() < minPt_ ) continue;
 
     cat::Jet aJet(aPatJet);
 

--- a/CatProducer/plugins/CATMETProducer.cc
+++ b/CatProducer/plugins/CATMETProducer.cc
@@ -38,7 +38,6 @@ cat::CATMETProducer::CATMETProducer(const edm::ParameterSet & iConfig) :
   src_(consumes<pat::METCollection>(iConfig.getParameter<edm::InputTag>("src"))),
   setUnclusteredEn_(iConfig.getParameter<bool>("setUnclusteredEn")),
   setjetMETSyst_(iConfig.getParameter<bool>("setJetMETSyst"))
-  
 {
   produces<std::vector<cat::MET> >();
 }
@@ -61,7 +60,7 @@ cat::CATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 			      aPatMET.shiftedPy(pat::MET::UnclusteredEnDown),
   			      aPatMET.shiftedSumEt(pat::MET::UnclusteredEnDown));
   }
-  
+
   aMET.setRawMET(aPatMET.MET::uncorP4().Pt());
 
   if (setjetMETSyst_){
@@ -80,8 +79,6 @@ cat::CATMETProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 
   }
 
-  
-  
   out->push_back(aMET);
 
   iEvent.put(out);

--- a/CatProducer/python/producers/electronProducer_cfi.py
+++ b/CatProducer/python/producers/electronProducer_cfi.py
@@ -8,6 +8,8 @@ catElectrons = cms.EDProducer("CATElectronProducer",
     vertexLabel = cms.InputTag('catVertex'),
     beamLineSrc = cms.InputTag("offlineBeamSpot"),
     rhoLabel = cms.InputTag("fixedGridRhoAll"),
+    minPt = cms.double(5.0),
+    maxEta = cms.double(2.5),
     electronIDSources = cms.PSet(),
     electronIDs = cms.vstring(), ## Defined in CatProducer/python/patTools/egmVersionedID_cff.py
 )

--- a/CatProducer/python/producers/jetProducer_cfi.py
+++ b/CatProducer/python/producers/jetProducer_cfi.py
@@ -9,6 +9,9 @@ catJets = cms.EDProducer('CATJetProducer',
     jetResSFFile = cms.string("CATTools/CatProducer/data/JER/Spring16_25nsV6_MC_SF_AK4PFchs.txt"),
     setGenParticle = cms.bool(True),
 
+    minPt = cms.double(5.0),
+    maxEta = cms.double(3.1),
+
     qgLikelihood = cms.InputTag(""), ## Keep this to be invalid and let it to be controlled by patTools/jetsQGLikelihood_cff.py
 )
 

--- a/CatProducer/python/producers/jetProducer_cfi.py
+++ b/CatProducer/python/producers/jetProducer_cfi.py
@@ -10,7 +10,7 @@ catJets = cms.EDProducer('CATJetProducer',
     setGenParticle = cms.bool(True),
 
     minPt = cms.double(5.0),
-    maxEta = cms.double(999.0), ## No cut on eta
+    maxEta = cms.double(1e9), ## No cut on eta
 
     qgLikelihood = cms.InputTag(""), ## Keep this to be invalid and let it to be controlled by patTools/jetsQGLikelihood_cff.py
 )

--- a/CatProducer/python/producers/jetProducer_cfi.py
+++ b/CatProducer/python/producers/jetProducer_cfi.py
@@ -10,7 +10,7 @@ catJets = cms.EDProducer('CATJetProducer',
     setGenParticle = cms.bool(True),
 
     minPt = cms.double(5.0),
-    maxEta = cms.double(3.1),
+    maxEta = cms.double(999.0), ## No cut on eta
 
     qgLikelihood = cms.InputTag(""), ## Keep this to be invalid and let it to be controlled by patTools/jetsQGLikelihood_cff.py
 )

--- a/CatProducer/python/producers/muonProducer_cfi.py
+++ b/CatProducer/python/producers/muonProducer_cfi.py
@@ -4,5 +4,8 @@ catMuons = cms.EDProducer("CATMuonProducer",
     src = cms.InputTag("slimmedMuons"),
     mcLabel = cms.InputTag("prunedGenParticles"),
     vertexLabel = cms.InputTag("catVertex"),
-    beamLineSrc = cms.InputTag("offlineBeamSpot")
+    beamLineSrc = cms.InputTag("offlineBeamSpot"),
+
+    minPt = cms.double(5.0),
+    maxEta = cms.double(2.5),
 )

--- a/CatProducer/python/producers/photonProducer_cfi.py
+++ b/CatProducer/python/producers/photonProducer_cfi.py
@@ -7,6 +7,8 @@ catPhotons = cms.EDProducer("CATPhotonProducer",
     mcLabel = cms.InputTag("prunedGenParticles"),
     vertexLabel = cms.InputTag('catVertex'),
     beamLineSrc = cms.InputTag("offlineBeamSpot"),
+    minPt = cms.double(5.0),
+    maxEta = cms.double(3.1),
     photonIDSources = cms.PSet(),
     photonIDs = cms.vstring(),  ## Defined in CatProducer/python/patTools/egmVersionedID_cff.py
 )

--- a/CatProducer/python/producers/photonProducer_cfi.py
+++ b/CatProducer/python/producers/photonProducer_cfi.py
@@ -8,7 +8,7 @@ catPhotons = cms.EDProducer("CATPhotonProducer",
     vertexLabel = cms.InputTag('catVertex'),
     beamLineSrc = cms.InputTag("offlineBeamSpot"),
     minPt = cms.double(5.0),
-    maxEta = cms.double(3.1),
+    maxEta = cms.double(1e9),
     photonIDSources = cms.PSet(),
     photonIDs = cms.vstring(),  ## Defined in CatProducer/python/patTools/egmVersionedID_cff.py
 )


### PR DESCRIPTION
Apply acceptance cuts during production to reduce file size.

**Changes**
  * Apply acceptance cuts pT and |eta| on muons, electrons and jets
  * _Note: changes number of Dstar candidates_ (EDIT: no change in uncompressed)

Event size with different cut values using ttbar MC
```
             Original  Loose(5GeV)  Medium(10GeV)  Tight(lepton>10GeV, jet>20GeV)
Muons        223.352   114.955      87.038         87.038
Electrons    205.677   169.578      135.161        135.161
Jets         759.17    642.272      642.272        435.55
PuppiJets    333.538   301.502      301.502        265.673
```
