### PR TITLE
Renewal D* producer.

### DIFF
--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -1,6 +1,6 @@
 from CATTools.CatProducer.catTemplate_cfg import *
 ## some options
-doSecVertex=True # for jpsi candidates
+doSecVertex=False # for jpsi candidates
 doDstar=True      # for Dstar meson.
     
 ## setting up arguements

--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -34,6 +34,7 @@ print "process.GlobalTag.globaltag =",process.GlobalTag.globaltag
 #### cat tools output
 ####################################################################
 process.load("CATTools.CatProducer.catCandidates_cff")    
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 from CATTools.CatProducer.catEventContent_cff import *
 process.catOut.outputCommands = catEventContent
 
@@ -53,7 +54,6 @@ if runGenTop:
     process.catOut.outputCommands.extend(['keep *_catGenTops_*_*',])
             
 if doSecVertex:
-    process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
     process.catOut.outputCommands.extend(catEventContentSecVertexs)
 
 if doDstar :

--- a/CatProducer/python/producers/dstarProducer_cfi.py
+++ b/CatProducer/python/producers/dstarProducer_cfi.py
@@ -3,10 +3,10 @@ import FWCore.ParameterSet.Config as cms
 catDstars = cms.EDProducer("CATDStarProducer",
   jetLabel = cms.InputTag("slimmedJets"),
   mcLabel  = cms.InputTag("prunedGenParticles"),
-  maxNumPFCand = cms.int32(5),
+  maxNumPFCand = cms.int32(9999),
   maxDeltaR = cms.double(0.2),
   d0MassCut = cms.double(0.5),
   d0MassWindow = cms.double(0.05),
   vertexLabel = cms.InputTag("catVertex"),
-  applyCut = cms.bool(True)
+  applySoftLeptonCut = cms.bool(True)
 )

--- a/DataFormats/interface/SecVertex.h
+++ b/DataFormats/interface/SecVertex.h
@@ -19,6 +19,7 @@ namespace cat {
   public:
     SecVertex();
     SecVertex(reco::VertexCompositeCandidate & aSecVertex);
+    SecVertex(SecVertex const & aSecVertex);
     virtual ~SecVertex();
 
     float lxy() const { return lxy_;}
@@ -29,6 +30,10 @@ namespace cat {
     int leptonID2() const { return leptonID2_;}
     int trackQuality2() const { return trackQuality2_;}
 
+    float JetDR() const { return jetDR_; }
+    float LegDR() const { return legDR_; }
+    float DiffMass() const { return diffMass_;}
+
     void setLxy(float i) { lxy_ = i; }
     void setL3D(float i) { l3D_ = i; }
     void setVProb(float i) { vProb_ = i; }
@@ -37,6 +42,7 @@ namespace cat {
     void setMCMatch(bool flag) { isMCMatch_ = flag ; }
     void setJetDR( float dR ) { jetDR_ = dR; }
     void setLegDR( float dR ) { legDR_ = dR; }
+    void setDiffMass( float diffMass) { diffMass_ = diffMass;}
 
     float dca() const { return dca_;}// distance of closest approach
     float dca(int i) const { 
@@ -51,13 +57,13 @@ namespace cat {
       else if (i==1) dca2_= dca ; 
       else if (i==2) dca3_ = dca;
     }
-
+    bool isMCMatch() const { return isMCMatch_;}
     float cxPtHypot() const { return cxPtHypot_;}// crossing point hypot
     void set_cxPtHypot(float i) { cxPtHypot_ = i; }
     float cxPtAbs() const { return cxPtAbs_;}// crossing point abs
     void set_cxPtAbs(float i) { cxPtAbs_ = i; }
   private:
-    float lxy_, l3D_, vProb_, dca_,dca2_,dca3_, cxPtHypot_, cxPtAbs_, jetDR_, legDR_ ;
+    float lxy_, l3D_, vProb_, dca_,dca2_,dca3_, cxPtHypot_, cxPtAbs_, jetDR_, legDR_ ,diffMass_;
     //int ipos_, ineg_;
     int leptonID1_, trackQuality1_;
     int leptonID2_, trackQuality2_;

--- a/DataFormats/src/SecVertex.cc
+++ b/DataFormats/src/SecVertex.cc
@@ -6,12 +6,30 @@ using namespace cat;
 SecVertex::SecVertex() {
   lxy_ = -9; l3D_ = -9 ; vProb_ = -9 ; dca_ = -9 ; dca2_ = -9; dca3_= -9; cxPtHypot_ = -9; cxPtAbs_ = -9;
   leptonID1_ = -1; leptonID2_ = -1;
-  trackQuality1_ = -1; trackQuality2_ =-1 ; jetDR_ = 999.;
+  trackQuality1_ = -1; trackQuality2_ =-1 ; jetDR_ = 999.; legDR_ = 999.; diffMass_ = -9;
   isMCMatch_ = false;
 }
 
 SecVertex::SecVertex(reco::VertexCompositeCandidate & aSecVertex) : reco::VertexCompositeCandidate( aSecVertex ) {
   SecVertex();
+}
+SecVertex::SecVertex(SecVertex const & aSecVertex) : reco::VertexCompositeCandidate( aSecVertex ) {
+  lxy_ = aSecVertex.lxy(); 
+  l3D_ = aSecVertex.l3D(); 
+  vProb_ = aSecVertex.vProb(); 
+  dca_ = aSecVertex.dca(0); 
+  dca2_ = aSecVertex.dca(1); 
+  dca3_ = aSecVertex.dca(2);
+  cxPtHypot_ = aSecVertex.cxPtHypot();
+  cxPtAbs_ = aSecVertex.cxPtAbs();
+  leptonID1_ = aSecVertex.leptonID1();
+  leptonID2_ = aSecVertex.leptonID2();
+  trackQuality1_ = aSecVertex.trackQuality1();
+  trackQuality2_ = aSecVertex.trackQuality2();
+  jetDR_ = aSecVertex.JetDR();
+  legDR_ = aSecVertex.LegDR();
+  isMCMatch_ = aSecVertex.isMCMatch();
+  diffMass_ = aSecVertex.DiffMass();
 }
 
 /// destructor


### PR DESCRIPTION
## D* producer is renewaled.
   * Modify SecVertex 
      * Add diffMass variable for analyzer and copy constructor to deep copy from SecVertx.
   * Switch off previous "SecVertexProducer'. 
      * Now, only D* producer is a only producer for D* analysis.(Not yet remove)
   * Changing method to find charmed mesons.
      * Now, all charged tracks are used.
      * To reduce size, only best meson(Ref. : mass) is selected for each candidate and jet.
      * Basically, softlepton cut is applied for D0, and D*.
      * JpsiMVA is removed for a while.
      * Additonal mass window cuts for J/psi and D* are applied. ( J/psi : 2<mass<4 / D* : diffM<0.3 ) 
### Size is Changed.
From 
```bash
catSecVertexs_catSecVertexs__CAT. 1950.36 545.394
catSecVertexs_catDstars_D0Cand_CAT. 1731.06 390.84
catSecVertexs_catDstars_JpsiMVACand_CAT. 929.824 268.163
catSecVertexs_catDstars_DstarCand_CAT. 452.529 95.4526
catSecVertexs_catDstars_JpsiCand_CAT. 163.151 13.4846
```
to
```bash
catSecVertexs_catDstars_D0Cand_CAT. 795.97 255.488
catSecVertexs_catDstars_DstarCand_CAT. 232.227 53.5116
catSecVertexs_catDstars_JpsiCand_CAT. 172.416 22.3598
```
   * About 5225(1311) -> 1199(330)
