### PR TITLE
Keep first primary vertex which fails quality cut

### DIFF
--- a/CatProducer/plugins/CATVertexProducer.cc
+++ b/CatProducer/plugins/CATVertexProducer.cc
@@ -46,11 +46,9 @@ void cat::CATVertexProducer::produce(edm::Event & iEvent, const edm::EventSetup 
 
   // only save the first vertex!
   // If the first vertex fails quality cut, put it in the 2nd place.
-  int ipv0 = -1, igoodpv0 = -1;
+  int igoodpv0 = -1;
   for ( int i=0; i<nPV; ++i ) {
     const auto& vtx = recVtxs->at(i);
-    if ( ipv0 < 0 ) ipv0 = i;
-
     if ( vtx.ndof() <= minNDOF_ ) continue;
     if ( maxAbsZ_ > 0 and std::abs(vtx.z()) > maxAbsZ_ ) continue;
     if ( maxd0_ > 0 and std::abs(vtx.position().rho()) > maxd0_ ) continue;
@@ -65,8 +63,8 @@ void cat::CATVertexProducer::produce(edm::Event & iEvent, const edm::EventSetup 
     out->push_back(recVtxs->at(igoodpv0));
     out->back().removeTracks();
   }
-  if ( ipv0 and ipv0 != igoodpv0 ) {
-    out->push_back(recVtxs->at(ipv0));
+  if ( nPV > 0 and igoodpv0 != 0 ) {
+    out->push_back(recVtxs->front());
     out->back().removeTracks();
   }
 


### PR DESCRIPTION
Current CATVertexProducer saves number of PV, number of good PV and the first good PV
With this PR, the producer will also keep the first PV before checking the quality cuts, to do a synchronization exercise.

If the first PV passes quality cuts, the contents will be exactly same as before. 
If the first PV fails cuts, keep the first good PV at front and append the first bad quality to the vertex collection.

- Case1-1: pv0 passes quality cut, pv1 passes quality cut... pvN passes quality cut
  - keep the pv0 only, catVertex.size() is 1. (same with the current version)
- Case1-2: pv0 passes quality cut, pv1 fails quality cut,...
  - keep the pv0 only, catVertex.size() is 1. (also same with the current version)
- Case2-1: pv0 fails quality cut, pv1 passes quality cut
  - keep pv1 at the first and pv0 at the second. catVertex.size() becomes 2.
- Case2-2: pv0 fails, pv1 fails, ... pvN passes quality cut
  - keep pvN at the first and pv0 at the second. catVertex.size() is 2.
- Case3: all pv fails
  - keep pv0 only. catVertex.size() is 1, of course nGoodPV=0.