### PR TITLE
use common input root file

### DIFF
--- a/CatAnalyzer/prod/ttbbLepJetsAnalyzer_cfg.py
+++ b/CatAnalyzer/prod/ttbbLepJetsAnalyzer_cfg.py
@@ -24,10 +24,10 @@ process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
-     fileNames = cms.untracked.vstring(
-        'root://cms-xrdr.sdfarm.kr:1094///xrd/store/group/CAT/TT_TuneCUETP8M1_13TeV-powheg-pythia8/v7-6-2_RunIIFall15MiniAODv2-PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext3-v1/160211_132614/0000/catTuple_1.root',
-        )
+     fileNames = cms.untracked.vstring()
 )
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["sig"]
 
 # PUReWeight
 # process.load("CATTools.CatProducer.pileupWeight_cff")

--- a/CatAnalyzer/test/run_TtbarDiLeptonAnalyzer_cfg.py
+++ b/CatAnalyzer/test/run_TtbarDiLeptonAnalyzer_cfg.py
@@ -8,11 +8,8 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
 process.options.allowUnscheduled = cms.untracked.bool(True)
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/MuonEG_Run2015D-16Dec2015-v1.root',]
-#process.source.fileNames = ['file:/xrootd/store/user/jhgoh/CATTools/sync/v7-6-3/TT_TuneCUETP8M1_13TeV-powheg-pythia8.root',]
-process.source.fileNames = [
-'file:/xrootd/store/group/CAT/TT_TuneCUETP8M1_13TeV-powheg-pythia8/v8-0-0_RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/160705_214937/0000/catTuple_1.root',
-]
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["sig"]
 
 process.load("CATTools.CatAnalyzer.ttll.ttbarDileptonKinSolutionAlgos_cff")
 process.load("CATTools.CatAnalyzer.filters_cff")

--- a/CatAnalyzer/test/run_h2muAnalyzer_cfg.py
+++ b/CatAnalyzer/test/run_h2muAnalyzer_cfg.py
@@ -8,21 +8,9 @@ process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
 process.options.allowUnscheduled = cms.untracked.bool(True)
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(),)
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/TT_TuneCUETP8M1_13TeV-powheg-pythia8.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/DoubleEG_Run2015D-16Dec2015-v2.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/DoubleMuon_Run2015D-16Dec2015-v1.root',]
-#process.source.fileNames = ['/store/user/jhgoh/CATTools/sync/v7-6-3/MuonEG_Run2015D-16Dec2015-v1.root',]
-#process.source.fileNames = ['file:%s/src/CATTools/CatProducer/prod/catTuple.root'%os.environ["CMSSW_BASE"]]
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["data"]
 
-process.source.fileNames = []
-for i in range(1):
-  process.source.fileNames.append('root://cms-xrdr.sdfarm.kr:1094///xrd/store/group/CAT/SingleMuon/v8-0-1_Run2016D-PromptReco-v2/160810_112606/0000/catTuple_%s.root'%(i+1))
-#process.source.fileNames=['root://cms-xrdr.sdfarm.kr:1094///xrd/store/group/CAT/SingleMuon/v8-0-1_Run2016D-PromptReco-v2/160810_112606/0000/catTuple_1.root']
-
-
-#process.source.fileNames = ['root://cms-xrdr.sdfarm.kr:1094///xrd/store/group/CAT/VBF_HToMuMu_M125_13TeV_powheg_pythia8/v8-0-1_RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v2/160810_125753/0000/catTuple_1.root']
-#process.source.fileNames = ['root://cms-xrdr.sdfarm.kr:1094///xrd/store/group/CAT/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v8-0-1_RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/160810_120220/0000/catTuple_324.root',]
 #txtfile = '../data/dataset/dataset_SingleMuon_Run2016E.txt'
 #txtfile = '../data/dataset/dataset_DYJets.txt'
 #f = open(txtfile)

--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -59,12 +59,12 @@ if doSecVertex:
 if doDstar :
     process.catOut.outputCommands.extend(['keep *_catDstars_*_*',])
 
-
 from PhysicsTools.PatAlgos.slimming.miniAOD_tools import miniAOD_customizeOutput
 miniAOD_customizeOutput(process.catOut)
     
 process.catOutpath = cms.EndPath(process.catOut)    
 process.schedule.append(process.catOutpath)
+
 ####################################################################
 #### setting up cat tools
 ####################################################################
@@ -83,35 +83,22 @@ process.maxEvents.input = options.maxEvents
 # Default file here for test purpose
 if not options.inputFiles:
     if useMiniAOD:
-        if runGenTop:
-            process.source.fileNames = [
-            '/store/mc/RunIISpring16MiniAODv2/GluGlu_HToMuMu_M125_13TeV_powheg_pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/10000/12B931FE-CD3A-E611-9844-0025905C3D98.root',
-#'/store/relval/CMSSW_7_4_15/RelValTTbar_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/0253820F-4772-E511-ADD3-002618943856.root',
-#'/store/relval/CMSSW_7_4_15/RelValTTbar_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/3848030E-4772-E511-AFCA-0026189438CC.root'
-                ]
-        else:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_15/RelValZMM_13/MINIAODSIM/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/10FF6E32-3C72-E511-87AD-0025905A60B4.root']
-    else:
-        if useGenTop:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_12/RelValTTbar_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2_v2-v1/00000/006F3660-4B5E-E511-B8FD-0025905B8596.root']
-        else:
-            process.source.fileNames = ['/store/relval/CMSSW_7_4_15/RelValZMM_13/GEN-SIM-RECO/PU25ns_74X_mcRun2_asymptotic_v2-v1/00000/18B13146-3872-E511-A382-00261894394D.root']
-
-if options.inputFiles:
+        from CATTools.Validation.commonTestInput_cff import commonTestMiniAODs
+        if runOnMC and runGenTop: process.source.fileNames = commonTestMiniAODs["sig"]
+        elif runOnMC: process.source.fileNames = commonTestMiniAODs["bkg"]
+        elif not runOnMC: process.source.fileNames = commonTestMiniAODs["data"]
+else:
     process.source.fileNames = options.inputFiles
+
 #pat input files are removed because it would not work if useMiniAOD is on.    
-
 ## to suppress the long output at the end of the job
-
-
 
 if options.maxEvents < 0:
     process.MessageLogger.cerr.FwkReport.reportEvery = 1000
-process.options.wantSummary = True
 
+process.options.wantSummary = True
 process.MessageLogger.cerr.threshold = 'ERROR'
 process.MessageLogger.suppressWarning = cms.untracked.vstring(["JetPtMismatchAtLowPt", "NullTransverseMomentum"])
-
 
 ## for debugging
 #process.options.wantSummary = True

--- a/CatProducer/test/runtests.sh
+++ b/CatProducer/test/runtests.sh
@@ -4,16 +4,13 @@ function die { echo $1: status $2 ;  exit $2; }
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'globalTag=80X_mcRun2_asymptotic_2016_miniAODv2_v1' \
-  'inputFiles=root://cmsxrootd.fnal.gov//store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/00000/004A0552-3929-E611-BD44-0025905A48F0.root' \
   || die 'Failure to run PAT2CAT from MiniAODSIM' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'globalTag=80X_mcRun2_asymptotic_2016_miniAODv2_v1' \
-  'inputFiles=root://cmsxrootd.fnal.gov//store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/50000/000FF6AC-9F2A-E611-A063-0CC47A4C8EB0.root' \
   || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=0' 'useMiniAOD=1' 'globalTag=80X_dataRun2_2016SeptRepro_v4' \
-  'inputFiles=root://cmsxrootd.fnal.gov///store/data/Run2016C/SingleMuon/MINIAOD/23Sep2016-v1/80000/82AF08FC-3B87-E611-A209-FA163E3F4268.root' \
   || die 'Failure to run PAT2CAT from MiniAOD real data' $?
 

--- a/CommonTools/test/run_ntupleMaker_cfg.py
+++ b/CommonTools/test/run_ntupleMaker_cfg.py
@@ -15,15 +15,10 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.MessageLogger.cerr.FwkReport.reportEvery = 10000
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(
-#'/store/user/youn/cat710_phy14_ttbar_2025_aod/catTuple_972.root'
-#in Kisti v736
-#"root://cms-xrdr.sdfarm.kr:1094///xrd/store/group/CAT/TT_TuneCUETP8M1_13TeV-powheg-pythia8/v7-3-6_RunIISpring15DR74-Asympt50ns_MCRUN2_74_V9A-v4/150820_215807/0000/catTuple_1.root",
-'file:catTuple.root'
-#'file:catTuple_DYJets.root'
-#'file:/cms/home/youn/work/cattool/tag711/cat/src/CATTools/CatProducer/prod/catTuple.root'
-    )
+    fileNames = cms.untracked.vstring()
 )
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["sig"]
 
 process.nEventsTotal = cms.EDProducer("EventCountProducer")
 

--- a/Validation/prod/TTLJ/analyze_bkg_cfg.py
+++ b/Validation/prod/TTLJ/analyze_bkg_cfg.py
@@ -9,10 +9,8 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 process.MessageLogger.cerr.FwkReport.reportEvery = 50000
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
-process.source.fileNames = [
-    '/store/group/CAT/WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v8-0-0_RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/160705_214832/0000/catTuple_1.root',
-]
-
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["bkg"]
 process.load("CATTools.CatAnalyzer.filters_cff")
 process.load("CATTools.Validation.ttljEventSelector_cff")
 process.load("CATTools.Validation.validation_cff")

--- a/Validation/prod/TTLJ/analyze_data_cfg.py
+++ b/Validation/prod/TTLJ/analyze_data_cfg.py
@@ -9,10 +9,8 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 process.MessageLogger.cerr.FwkReport.reportEvery = 50000
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
-process.source.fileNames = [
-    '/store/group/CAT/SingleMuon/v8-0-0_Run2016B-PromptReco-v2/160705_213508/0000/catTuple_1.root',
-]
-
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["data"]
 process.load("CATTools.CatAnalyzer.filters_cff")
 process.load("CATTools.Validation.ttljEventSelector_cff")
 process.load("CATTools.Validation.validation_cff")

--- a/Validation/prod/TTLJ/analyze_sig_cfg.py
+++ b/Validation/prod/TTLJ/analyze_sig_cfg.py
@@ -9,10 +9,8 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 process.MessageLogger.cerr.FwkReport.reportEvery = 50000
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
-process.source.fileNames = [
-    '/store/group/CAT/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v8-0-0_RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/160707_125444/0000/catTuple_1.root',
-]
-
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["sig"]
 process.load("CATTools.CatAnalyzer.filters_cff")
 process.load("CATTools.Validation.ttljEventSelector_cff")
 process.load("CATTools.CatAnalyzer.ttll.ttllGenFilters_cff")

--- a/Validation/prod/TTLL/analyze_bkg_cfg.py
+++ b/Validation/prod/TTLL/analyze_bkg_cfg.py
@@ -9,10 +9,8 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 process.MessageLogger.cerr.FwkReport.reportEvery = 50000
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
-process.source.fileNames = [
-    '/store/group/CAT/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v8-0-0_RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/160705_214259/0000/catTuple_1.root',
-]
-
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["bkg"]
 process.load("CATTools.CatAnalyzer.filters_cff")
 process.load("CATTools.Validation.ttllEventSelector_cff")
 process.load("CATTools.Validation.validation_cff")

--- a/Validation/prod/TTLL/analyze_data_cfg.py
+++ b/Validation/prod/TTLL/analyze_data_cfg.py
@@ -9,10 +9,8 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 process.MessageLogger.cerr.FwkReport.reportEvery = 50000
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
-process.source.fileNames = [
-    '/store/group/CAT/MuonEG/v8-0-0_Run2016B-PromptReco-v2/160807_174617/0000/catTuple_1.root',
-]
-
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["data"]
 process.load("CATTools.CatAnalyzer.filters_cff")
 process.load("CATTools.Validation.ttllEventSelector_cff")
 process.load("CATTools.Validation.validation_cff")

--- a/Validation/prod/TTLL/analyze_sig_cfg.py
+++ b/Validation/prod/TTLL/analyze_sig_cfg.py
@@ -9,10 +9,8 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 process.MessageLogger.cerr.FwkReport.reportEvery = 50000
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
-process.source.fileNames = [
-    '/store/group/CAT/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v8-0-0_RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/160707_125444/0000/catTuple_1.root',
-]
-
+from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
+process.source.fileNames = commonTestCATTuples["sig"]
 process.load("CATTools.CatAnalyzer.filters_cff")
 process.load("CATTools.Validation.ttllEventSelector_cff")
 process.load("CATTools.CatAnalyzer.ttll.ttllGenFilters_cff")

--- a/Validation/python/commonTestInput_cff.py
+++ b/Validation/python/commonTestInput_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+commonTestCATTuples = {
+    "sig":cms.untracked.vstring("/store/group/CAT/TT_TuneCUETP8M1_13TeV-powheg-pythia8/v8-0-3_RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14_ext3-v1/161205_142558/0000/catTuple_1.root",),
+    "bkg":cms.untracked.vstring("/store/group/CAT/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/v8-0-3_RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/161205_142228/0000/catTuple_1.root",),
+    "data":cms.untracked.vstring("/store/group/CAT/DoubleEG/v8-0-3_Run2016G-23Sep2016-v1/161204_005359/0000/catTuple_1.root"),
+}
+
+commonTestMiniAODs = {
+    "sig":cms.untracked.vstring("root://cmsxrootd.fnal.gov//store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext4-v1/00000/004A0552-3929-E611-BD44-0025905A48F0.root",),
+    "bkg":cms.untracked.vstring("root://cmsxrootd.fnal.gov//store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/50000/000FF6AC-9F2A-E611-A063-0CC47A4C8EB0.root",),
+    "data":cms.untracked.vstring("root://cmsxrootd.fnal.gov///store/data/Run2016C/SingleMuon/MINIAOD/23Sep2016-v1/80000/82AF08FC-3B87-E611-A209-FA163E3F4268.root",),
+}


### PR DESCRIPTION
Added a cff file to define common set of test input root files, both MiniAOD (from the xrootd service) and catTuple.

"sig"(inclusive ttbar), "bkg"(DYJets) and "data"(DoubleEG) are predefined in the cff file, therefore analyzers can take the root file with the following syntax.

`from CATTools.Validation.commonTestInput_cff import commonTestCATTuples
process.source.fileNames = commonTestCATTuples["sig"]`