### PR TITLE
Switch boolean flags to bitset to reduce file size

### DIFF
--- a/CatProducer/plugins/CATElectronProducer.cc
+++ b/CatProducer/plugins/CATElectronProducer.cc
@@ -47,7 +47,7 @@ namespace cat {
   private:
     
     float getEffArea( float dR, float scEta );
-    int getSNUID(float, float, float, float, float, float, int, bool, float);
+    std::bitset<4> getSNUID(float, float, float, float, float, float, int, bool, float);
     edm::EDGetTokenT<edm::View<pat::Electron> > src_;
     edm::EDGetTokenT<edm::View<pat::Electron> > unsmearedElecToken_;
     edm::EDGetTokenT<reco::VertexCollection> vertexLabel_;
@@ -302,7 +302,7 @@ cat::CATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
       eoverp = std::abs(1.0/aPatElectron.ecalEnergy() - aPatElectron.eSuperClusterOverP()/aPatElectron.ecalEnergy() ) ;
     }
 
-    int snu_id = getSNUID(aPatElectron.full5x5_sigmaIetaIeta(), abs(aPatElectron.deltaEtaSuperClusterTrackAtVtx() ), abs(aPatElectron.deltaPhiSuperClusterTrackAtVtx() ), aPatElectron.hcalOverEcal(), eoverp, abs(aElectron.dz()) , aPatElectron.gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS), aPatElectron.passConversionVeto(),aPatElectron.superCluster()->eta() );
+    auto snu_id = getSNUID(aPatElectron.full5x5_sigmaIetaIeta(), abs(aPatElectron.deltaEtaSuperClusterTrackAtVtx() ), abs(aPatElectron.deltaPhiSuperClusterTrackAtVtx() ), aPatElectron.hcalOverEcal(), eoverp, abs(aElectron.dz()) , aPatElectron.gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS), aPatElectron.passConversionVeto(),aPatElectron.superCluster()->eta() );
     aElectron.setSNUID(snu_id);
 
     // Fill the validity flag of triggered MVA
@@ -344,7 +344,7 @@ cat::CATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
 }
 
 
-int cat::CATElectronProducer::getSNUID(float full5x5_sigmaIetaIeta, float deltaEtaSuperClusterTrackAtVtx, float deltaPhiSuperClusterTrackAtVtx, float hoverE, float eoverp, float dz, int exp_miss_innerhits, bool pass_conversion_veto, float sceta){
+std::bitset<4> cat::CATElectronProducer::getSNUID(float full5x5_sigmaIetaIeta, float deltaEtaSuperClusterTrackAtVtx, float deltaPhiSuperClusterTrackAtVtx, float hoverE, float eoverp, float dz, int exp_miss_innerhits, bool pass_conversion_veto, float sceta){
 
   //----------------------------------------------------------------------
   // Barrel electron cut values
@@ -370,7 +370,7 @@ int cat::CATElectronProducer::getSNUID(float full5x5_sigmaIetaIeta, float deltaE
   double l_e_ep      [4] = { 0.15, 0.14, 0.13,0.0129};
   int    l_e_missHits[4] = { 3, 1, 1, 1};
 
-  int flag_id=0;
+  std::bitset<4> idBit;
   for(int i=0; i < 4; i++){
     bool pass_id=true;
     if ( std::abs(sceta) < 1.479 ){
@@ -391,10 +391,10 @@ int cat::CATElectronProducer::getSNUID(float full5x5_sigmaIetaIeta, float deltaE
       if(exp_miss_innerhits > l_e_missHits[i])pass_id = false;
       if(!pass_conversion_veto) pass_id = false;
     }
-    if(pass_id)flag_id += pow(10,i);
+    if(pass_id) idBit[i] = 1;
   }
 
-  return flag_id;
+  return idBit;
 }
 
 float

--- a/DataFormats/interface/Electron.h
+++ b/DataFormats/interface/Electron.h
@@ -7,6 +7,8 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 
+#include <bitset>
+
 // Define typedefs for convenience
 namespace cat {
   class Electron;
@@ -35,9 +37,9 @@ namespace cat {
     }
     
     float scEta() const { return scEta_; }
-    bool passConversionVeto() const { return passConversionVeto_; }
-    bool isGsfCtfScPixChargeConsistent() const{ return isGsfCtfScPixChargeConsistent_; }
-    bool isEB() const{ return isEB_; }
+    bool passConversionVeto() const { return idBits_[0]; }
+    bool isGsfCtfScPixChargeConsistent() const{ return idBits_[1]; }
+    bool isEB() const{ return idBits_[2]; }
 
     float ipsignificance() const { return ipsig_;}
 
@@ -46,8 +48,15 @@ namespace cat {
     float shiftedEnDown() const {return 1-shiftedEn();}
     float shiftedEnUp() const {return  1+shiftedEn();}
     
-    int snuID() const {return snuID_;}
-    bool isTrigMVAValid() const { return isTrigMVAValid_; }
+    int snuID() const {
+      int idflag = 0, base = 1;
+      for ( unsigned int i=0; i<snuID_.size(); ++i ) {
+        if ( snuID_[i] ) idflag += base;
+        base *= 10;
+      }
+      return idflag;
+    }
+    bool isTrigMVAValid() const { return idBits_[3]; }
     
     void setElectronIDs(const std::vector<pat::Electron::IdPair> & ids) { electronIDs_ = ids; }
     void setElectronID(pat::Electron::IdPair ids) { electronIDs_.push_back(ids); }
@@ -60,12 +69,12 @@ namespace cat {
     }
     
     void setscEta(float i) { scEta_ = i; }
-    void setPassConversionVeto(bool i) {  passConversionVeto_ = i; }
-    void setIsGsfCtfScPixChargeConsistent(bool d) { isGsfCtfScPixChargeConsistent_ = d ; }
-    void setIsEB(bool d) { isEB_ = d ; }
+    void setPassConversionVeto(bool i) {  idBits_[0] = i; }
+    void setIsGsfCtfScPixChargeConsistent(bool d) { idBits_[1] = d ; }
+    void setIsEB(bool d) { idBits_[2] = d ; }
 
-    void setSNUID(int id) {snuID_ = id;}
-    void setTrigMVAValid(bool val) { isTrigMVAValid_ = val; }
+    void setSNUID(std::bitset<4> id) {snuID_ = id;}
+    void setTrigMVAValid(bool val) { idBits_[3] = val; }
     void setIpSignficance(float ipsig) {ipsig_ = ipsig;}
 
     void setSmearedScale(const float scale) { smearedScale_ = scale; }
@@ -81,12 +90,8 @@ namespace cat {
     float relIso04_;
     float ipsig_;
     float scEta_;
-    bool passConversionVeto_;
-    bool isGsfCtfScPixChargeConsistent_;
-    bool isEB_;
-    
-    int snuID_;
-    bool isTrigMVAValid_;
+    std::bitset<4> idBits_; // passConversionVeto, isGsfCtfScPixChargeConsistent, isEB, isTrigMVAValid
+    std::bitset<4> snuID_;
   };
 }
 

--- a/DataFormats/interface/GenJet.h
+++ b/DataFormats/interface/GenJet.h
@@ -40,8 +40,8 @@ namespace cat {
 
     MCParticle hadron_;
     //parton flavour
-    int partonFlavour_;
-    int partonPdgId_;
+    short partonFlavour_;
+    short partonPdgId_;
 
   };
 }

--- a/DataFormats/interface/GenTop.h
+++ b/DataFormats/interface/GenTop.h
@@ -23,6 +23,7 @@ namespace cat {
   typedef std::vector<GenTop>              GenTopCollection;
   typedef edm::Ref<GenTopCollection>       GenTopRef;
   typedef edm::RefVector<GenTopCollection> GenTopRefVector;
+
 }
 
 namespace cat {
@@ -35,6 +36,18 @@ namespace cat {
     virtual ~GenTop();
 
     typedef std::vector<math::XYZTLorentzVector> LorentzVectors;
+
+    struct CHKeys {
+      enum {
+        allHadronic = 0,
+        semiLeptonic, semiLeptonicMuo, semiLeptonicEle, semiLeptonicTau,
+        diLeptonic, diLeptonicMuoMuo, diLeptonicMuoEle, diLeptonicEleEle,
+        diLeptonicTauMuo, diLeptonicTauEle, diLeptonicTauTau, 
+        ttbbDecay,
+        taunic1, taunic2,
+        SIZE
+      };
+    };
 
     // status 3
     const math::XYZTLorentzVector topquark1() const { return tops_[0]; }
@@ -119,40 +132,40 @@ namespace cat {
 
     bool taunic(int i = -1) const {
       bool hasTau = false;
-      if( i == -1) hasTau = taunic1_ || taunic2_;
-      if( i == 0 ) hasTau = taunic1_;
-      if( i == 1 ) hasTau = taunic2_;
+      if( i == -1) hasTau = chBit_[CHKeys::taunic1] || chBit_[CHKeys::taunic2];
+      if( i == 0 ) hasTau = chBit_[CHKeys::taunic1];
+      if( i == 1 ) hasTau = chBit_[CHKeys::taunic2];
       return hasTau;
     }
 
-    bool allHadronic() const { return allHadronic_; }
+    bool allHadronic() const { return chBit_[CHKeys::allHadronic]; }
 
     bool semiLeptonic(int i = -1) const {
       bool decay = false;
-      if( i == -1) decay = semiLeptonic_;
-      if( i == 0) decay = semiLeptonicMuo_ || semiLeptonicEle_;
-      if( i == 1) decay = ( semiLeptonicMuo_ || semiLeptonicEle_ ) && !semiLeptonicTau_;
+      if( i == -1) decay = chBit_[CHKeys::semiLeptonic];
+      if( i == 0) decay = chBit_[CHKeys::semiLeptonicMuo] || chBit_[CHKeys::semiLeptonicEle];
+      if( i == 1) decay = ( chBit_[CHKeys::semiLeptonicMuo] || chBit_[CHKeys::semiLeptonicEle] ) && !chBit_[CHKeys::semiLeptonicTau];
       return decay;
     }
 
-    bool semiLeptonicMuo() const { return semiLeptonicMuo_; }
-    bool semiLeptonicEle() const { return semiLeptonicEle_; }
-    bool semiLeptonicTau() const { return semiLeptonicTau_; }
+    bool semiLeptonicMuo() const { return chBit_[CHKeys::semiLeptonicMuo]; }
+    bool semiLeptonicEle() const { return chBit_[CHKeys::semiLeptonicEle]; }
+    bool semiLeptonicTau() const { return chBit_[CHKeys::semiLeptonicTau]; }
 
     bool diLeptonic(int i = -1) const {
       bool decay = false;
-      if( i == -1) decay = diLeptonic_;
-      if( i == 0) decay = diLeptonicMuoMuo_ || diLeptonicMuoEle_ || diLeptonicEleEle_;
-      if( i == 1) decay = ( diLeptonicMuoMuo_ || diLeptonicMuoEle_ || diLeptonicEleEle_) && !( diLeptonicTauMuo_ || diLeptonicTauEle_ || diLeptonicTauTau_);
+      if( i == -1) decay = chBit_[CHKeys::diLeptonic];
+      if( i == 0) decay = chBit_[CHKeys::diLeptonicMuoMuo] || chBit_[CHKeys::diLeptonicMuoEle] || chBit_[CHKeys::diLeptonicEleEle];
+      if( i == 1) decay = ( chBit_[CHKeys::diLeptonicMuoMuo] || chBit_[CHKeys::diLeptonicMuoEle] || chBit_[CHKeys::diLeptonicEleEle]) && !( chBit_[CHKeys::diLeptonicTauMuo] || chBit_[CHKeys::diLeptonicTauEle] || chBit_[CHKeys::diLeptonicTauTau]);
       return decay;
     }
 
-    bool diLeptonicMuoMuo() const { return diLeptonicMuoMuo_; }
-    bool diLeptonicMuoEle() const { return diLeptonicMuoEle_; }
-    bool diLeptonicEleEle() const { return diLeptonicEleEle_; }
-    bool diLeptonicTauMuo() const { return diLeptonicTauMuo_; }
-    bool diLeptonicTauEle() const { return diLeptonicTauEle_; }
-    bool diLeptonicTauTau() const { return diLeptonicTauTau_; }
+    bool diLeptonicMuoMuo() const { return chBit_[CHKeys::diLeptonicMuoMuo]; }
+    bool diLeptonicMuoEle() const { return chBit_[CHKeys::diLeptonicMuoEle]; }
+    bool diLeptonicEleEle() const { return chBit_[CHKeys::diLeptonicEleEle]; }
+    bool diLeptonicTauMuo() const { return chBit_[CHKeys::diLeptonicTauMuo]; }
+    bool diLeptonicTauEle() const { return chBit_[CHKeys::diLeptonicTauEle]; }
+    bool diLeptonicTauTau() const { return chBit_[CHKeys::diLeptonicTauTau]; }
 
     int NbQuarksTop() const { return NbQuarksTop_ ; }
     int NbQuarksNoTop() const { return NbQuarksNoTop_ ; }
@@ -299,115 +312,100 @@ namespace cat {
     LorentzVectors bJets_;
     LorentzVectors bJetsFromTop_;
     LorentzVectors JetsFromW_;
-    std::vector<int> JetsFlavourFromW_;
+    std::vector<short> JetsFlavourFromW_;
     LorentzVectors addbJets_;
     LorentzVectors addcJets_;
     LorentzVectors addbJetsHad_;
     LorentzVectors addcJetsHad_;
     LorentzVectors addJets_;
     LorentzVectors quarksfromW_;
-    std::vector<int> qflavourfromW_;
+    std::vector<short> qflavourfromW_;
 
     float ttbarmass_;
 
-    bool allHadronic_;
-    bool semiLeptonic_;
-    bool semiLeptonicMuo_;
-    bool semiLeptonicEle_;
-    bool semiLeptonicTau_;
-    bool diLeptonic_;
-    bool diLeptonicMuoMuo_;
-    bool diLeptonicMuoEle_;
-    bool diLeptonicEleEle_;
-    bool diLeptonicTauMuo_;
-    bool diLeptonicTauEle_;
-    bool diLeptonicTauTau_;
+    std::bitset<CHKeys::SIZE> chBit_;
 
-    bool ttbbDecay_;
+    typedef unsigned char uchar;
+    uchar NbJets_;
+    uchar NbJets10_;
+    uchar NbJets15_;
+    uchar NbJets20_;
+    uchar NbJets25_;
+    uchar NbJets30_;
+    uchar NbJets40_;
 
-    bool taunic1_;
-    bool taunic2_;
+    uchar NbJetsBHad_;
+    uchar NbJets10BHad_;
+    uchar NbJets15BHad_;
+    uchar NbJets20BHad_;
+    uchar NbJets25BHad_;
+    uchar NbJets30BHad_;
+    uchar NbJets40BHad_;
 
-    int NbJets_;
-    int NbJets10_;
-    int NbJets15_;
-    int NbJets20_;
-    int NbJets25_;
-    int NbJets30_;
-    int NbJets40_;
+    uchar NaddbJetsBHad_;
+    uchar NaddbJets20BHad_;
+    uchar NaddbJets40BHad_;
 
-    int NbJetsBHad_;
-    int NbJets10BHad_;
-    int NbJets15BHad_;
-    int NbJets20BHad_;
-    int NbJets25BHad_;
-    int NbJets30BHad_;
-    int NbJets40BHad_;
+    uchar NaddcJetsCHad_;
+    uchar NaddcJets20CHad_;
+    uchar NaddcJets40CHad_;
 
-    int NaddbJetsBHad_;
-    int NaddbJets20BHad_;
-    int NaddbJets40BHad_;
-
-    int NaddcJetsCHad_;
-    int NaddcJets20CHad_;
-    int NaddcJets40CHad_;
-
-    int NbJetsNoTop_;
-    int NbJets10NoTop_;
-    int NbJets15NoTop_;
-    int NbJets20NoTop_;
-    int NbJets25NoTop_;
-    int NbJets30NoTop_;
-    int NbJets40NoTop_;
+    uchar NbJetsNoTop_;
+    uchar NbJets10NoTop_;
+    uchar NbJets15NoTop_;
+    uchar NbJets20NoTop_;
+    uchar NbJets25NoTop_;
+    uchar NbJets30NoTop_;
+    uchar NbJets40NoTop_;
 
 
-    int NcJets_;
-    int NcJets10_;
-    int NcJets15_;
-    int NcJets20_;
-    int NcJets25_;
-    int NcJets30_;
-    int NcJets40_;
+    uchar NcJets_;
+    uchar NcJets10_;
+    uchar NcJets15_;
+    uchar NcJets20_;
+    uchar NcJets25_;
+    uchar NcJets30_;
+    uchar NcJets40_;
 
-    int NaddcJets_;
-    int NaddcJets10_;
-    int NaddcJets20_;
-    int NaddcJets30_;
-    int NaddcJets40_;
+    uchar NaddcJets_;
+    uchar NaddcJets10_;
+    uchar NaddcJets20_;
+    uchar NaddcJets30_;
+    uchar NaddcJets40_;
 
-    int NcJetsCHad_;
-    int NcJets10CHad_;
-    int NcJets15CHad_;
-    int NcJets20CHad_;
-    int NcJets25CHad_;
-    int NcJets30CHad_;
-    int NcJets40CHad_;
+    uchar NcJetsCHad_;
+    uchar NcJets10CHad_;
+    uchar NcJets15CHad_;
+    uchar NcJets20CHad_;
+    uchar NcJets25CHad_;
+    uchar NcJets30CHad_;
+    uchar NcJets40CHad_;
 
-    int NbQuarks_;
-    int NbQuarksNoTop_;
-    int NbQuarksTop_;
-    int NbQuarks20_;
-    int NbQuarks40_;
-    int NaddbQuarks20_;
-    int NaddbQuarks40_;
+    uchar NbQuarks_;
+    uchar NbQuarksNoTop_;
+    uchar NbQuarksTop_;
+    uchar NbQuarks20_;
+    uchar NbQuarks40_;
+    uchar NaddbQuarks20_;
+    uchar NaddbQuarks40_;
 
-    int NcQuarks_;
-    int NaddcQuarks_;
-    //int NaddcQuarks20_;
-    //int NaddcQuarks40_;
+    uchar NcQuarks_;
+    uchar NaddcQuarks_;
+    //uchar NaddcQuarks20_;
+    //uchar NaddcQuarks40_;
 
-    int NJets_;
-    int NJets10_;
-    int NJets15_;
-    int NJets20_;
-    int NJets25_;
-    int NJets30_;
-    int NJets40_;
+    uchar NJets_;
+    uchar NJets10_;
+    uchar NJets15_;
+    uchar NJets20_;
+    uchar NJets25_;
+    uchar NJets30_;
+    uchar NJets40_;
 
-    int NaddJets20_;
-    int NaddJets40_;
+    uchar NaddJets20_;
+    uchar NaddJets40_;
 
-    int NWJets_;
+    uchar NWJets_;
 
     float dRaddJets_;
 

--- a/DataFormats/interface/GenWeights.h
+++ b/DataFormats/interface/GenWeights.h
@@ -74,7 +74,7 @@ public:
   void addWeight(const float w) { weights_.push_back(w); }
 
 private:
-  int id1_, id2_;
+  char id1_, id2_;
   float x1_, x2_, qScale_;
 
   float genWeight_, lheWeight_;

--- a/DataFormats/interface/Jet.h
+++ b/DataFormats/interface/Jet.h
@@ -8,7 +8,8 @@
 #include "DataFormats/PatCandidates/interface/JetCorrFactors.h"
 
 #include <string>
-#include <boost/array.hpp>
+//#include <boost/array.hpp>
+#include <bitset>
 
 // Define typedefs for convenience
 namespace cat {
@@ -61,11 +62,11 @@ namespace cat {
     Jet(const reco::LeafCandidate & aJet);
     virtual ~Jet();
 
-    bool LooseId() const { return looseJetID_; }// temp for backward comp
-    bool TightId() const { return tightJetID_; }// temp for backward comp
-    bool looseJetID() const { return looseJetID_; }
-    bool tightJetID() const { return tightJetID_; }
-    bool tightLepVetoJetID() const { return tightLepVetoJetID_; }
+    inline bool LooseId() const { return looseJetID(); }// temp for backward comp
+    inline bool TightId() const { return tightJetID(); }// temp for backward comp
+    bool looseJetID() const { return jetIdBits_[0]; }
+    bool tightJetID() const { return jetIdBits_[1]; }
+    bool tightLepVetoJetID() const { return jetIdBits_[2]; }
 
     float pileupJetId() const { return pileupJetId_; }
     float chargedEmEnergyFraction() const { return chargedEmEnergyFraction_; }
@@ -105,9 +106,9 @@ namespace cat {
 
     float qgLikelihood() const { return qgLikelihood_; }
     
-    void setLooseJetID(bool id) { looseJetID_ = id; }
-    void setTightJetID(bool id) { tightJetID_ = id; }
-    void setTightLepVetoJetID(bool id) { tightLepVetoJetID_ = id; }
+    void setLooseJetID(bool id) { jetIdBits_[0] = id; }
+    void setTightJetID(bool id) { jetIdBits_[1] = id; }
+    void setTightLepVetoJetID(bool id) { jetIdBits_[2] = id; }
 
     void setPileupJetId(float f) { pileupJetId_ = f;}
     void setChargedEmEnergyFraction(float f) { chargedEmEnergyFraction_ = f; }
@@ -140,9 +141,7 @@ namespace cat {
 
     edm::FwdRef<reco::GenJetCollection>  genJetFwdRef_;
 
-    bool looseJetID_;
-    bool tightJetID_;
-    bool tightLepVetoJetID_;
+    std::bitset<3> jetIdBits_; // loose,tight,tightLepVeto
 
     float pileupJetId_;
     float chargedEmEnergyFraction_;
@@ -152,14 +151,14 @@ namespace cat {
     //float pairDiscriVector_;
      /// b tagging information
     float vtxMass_;
-    int vtxNtracks_;
+    unsigned short vtxNtracks_;
     float vtx3DVal_;
     float vtx3DSig_;
 
     //parton flavour
-    int partonFlavour_;
-    int hadronFlavour_;
-    int partonPdgId_;
+    short partonFlavour_;
+    short hadronFlavour_;
+    short partonPdgId_;
 
     float shiftedEnDown_;
     float shiftedEnUp_;

--- a/DataFormats/interface/Lepton.h
+++ b/DataFormats/interface/Lepton.h
@@ -22,10 +22,10 @@ namespace cat {
     Lepton(const reco::LeafCandidate & aLepton);
     virtual ~Lepton();
 
-    bool isPF() const{ return isPF_; }
-    bool isTight() const { return isTight_; }
-    bool isMedium() const { return isMedium_; }
-    bool isLoose() const { return isLoose_; }
+    bool isPF() const{ return idBits_[0]; }
+    bool isTight() const { return idBits_[1]; }
+    bool isMedium() const { return idBits_[2]; }
+    bool isLoose() const { return idBits_[3]; }
     
     float dxy() const { return dxy_; }
     float dz() const { return dz_; }
@@ -59,19 +59,19 @@ namespace cat {
       return charged + ( corNeutralIso>0 ? corNeutralIso : 0 ) ;
     }
     float relIso(float dR=0.3, float dBetaFactor = 0.5) const {
-	float abs = absIso(dR, dBetaFactor)/this->pt();
-	return abs >=0 ? abs : -1;
+      float abs = absIso(dR, dBetaFactor)/this->pt();
+      return abs >=0 ? abs : -1;
     }
     // to be undated with shifts on the fly!
     /* float shiftedEnDown() const {return  shiftedEnDown_;} */
     /* float shiftedEnUp() const {return  shiftedEnUp_;} */
 
-    bool mcMatched() const { return mcMatched_; }
+    bool mcMatched() const { return idBits_[4]; }
 
-    void setIsPF(bool d) { isPF_ = d ; }
-    void setIsTight(bool d) { isTight_ = d; }
-    void setIsMedium(bool d) { isMedium_ = d; }
-    void setIsLoose(bool d) { isLoose_ = d; }
+    void setIsPF(bool d) { idBits_[0] = d ; }
+    void setIsTight(bool d) { idBits_[1] = d; }
+    void setIsMedium(bool d) { idBits_[2] = d; }
+    void setIsLoose(bool d) { idBits_[3] = d; }
 
     void setDz(float d) { dz_ = d; }
     void setDxy(float d) { dxy_ = d; }
@@ -87,15 +87,11 @@ namespace cat {
     void setPhotonIso04(float i) { photonIso04_ = i; }
 
     void setMiniRelIso(float i){relMiniIso_=i;}
-
-    void setMCMatched(bool m) { mcMatched_ = m; }
+    void setMCMatched(bool m) { idBits_[4] = m; }
     
   private:
 
-    bool isPF_;
-    bool isTight_;
-    bool isMedium_;
-    bool isLoose_;    
+    std::bitset<5> idBits_; // isPF, isTight, isMedium, isLoose, mcMatched
 
     float dz_;
     float dxy_;
@@ -111,8 +107,6 @@ namespace cat {
     float photonIso04_;
 
     float relMiniIso_;
-
-    bool mcMatched_;
   };
 }
 

--- a/DataFormats/interface/Muon.h
+++ b/DataFormats/interface/Muon.h
@@ -22,8 +22,8 @@ namespace cat {
     Muon(const reco::LeafCandidate & aMuon);
     virtual ~Muon();
     
-    bool isGlobalMuon() const { return isGlobalMuon_; }
-    bool isSoftMuon() const { return isSoftMuon_; }
+    bool isGlobalMuon() const { return idBits_[0]; }
+    bool isSoftMuon() const { return idBits_[1]; }
     bool isPFMuon() const { return this->isPF(); }
     bool isTightMuon() const { return this->isTight(); }
     bool isMediumMuon() const { return this->isMedium(); }
@@ -43,8 +43,8 @@ namespace cat {
     float shiftedEnDown() const {return 1-shiftedEn();}
     float shiftedEnUp() const {return  1+shiftedEn();}
 
-    void setIsGlobalMuon(bool d) { isGlobalMuon_ = d; }
-    void setIsSoftMuon(bool d) { isSoftMuon_ = d; }
+    void setIsGlobalMuon(bool d) { idBits_[0] = d; }
+    void setIsSoftMuon(bool d) { idBits_[1] = d; }
 
     void setNormalizedChi2(float d) { normalizedChi2_ = d; }
     void setNumberOfValidHits(int i) { numberOfValidHits_ = i; }
@@ -59,17 +59,17 @@ namespace cat {
     
   private:
 
-    bool isGlobalMuon_;
-    bool isSoftMuon_;
+    std::bitset<2> idBits_; // isGlobalMuon, isSoftMuon
 
     float normalizedChi2_;
     float ipsig_;
 
-    int numberOfValidHits_;
-    int numberOfValidMuonHits_;
-    int numberOfMatchedStations_;
-    int numberOfValidPixelHits_;
-    int trackerLayersWithMeasurement_;
+    typedef unsigned char uchar;
+    uchar numberOfValidHits_;
+    uchar numberOfValidMuonHits_;
+    uchar numberOfMatchedStations_;
+    uchar numberOfValidPixelHits_;
+    uchar trackerLayersWithMeasurement_;
   };
 }
 

--- a/DataFormats/interface/Photon.h
+++ b/DataFormats/interface/Photon.h
@@ -41,15 +41,15 @@ namespace cat {
     float neutralHadronIsoWithEA(); 
     float photonIsoWithEA(); 
     
-    bool isPF() const{ return isPF_; }
-    bool isTight() const { return isTight_; }
-    bool isMedium() const { return isMedium_; }
-    bool isLoose() const { return isLoose_; }
+    bool isPF() const{ return idBits_[0]; }
+    bool isTight() const { return idBits_[1]; }
+    bool isMedium() const { return idBits_[2]; }
+    bool isLoose() const { return idBits_[3]; }
     
-    bool passMVA() const  { return passMVA_; }
+    bool passMVA() const  { return idBits_[4]; }
     
-    bool PassElectronVeto() const { return passElVeto_;}
-    bool HasPixelSeed() const { return hasPixSeed_;}
+    bool PassElectronVeto() const { return idBits_[5];}
+    bool HasPixelSeed() const { return idBits_[6];}
     
     float SigmaiEtaiEta() const {return iEtaiEta_;}
     float r9() const {return r9_;}
@@ -61,7 +61,7 @@ namespace cat {
 
     float smearedScale() const { return smearedScale_; }
 
-    bool mcMatched() const { return mcMatched_; }
+    bool mcMatched() const { return idBits_[7]; }
 
     float getEffArea(IsoType iso_type, float scEta) ;
     /// Set class variables
@@ -77,13 +77,13 @@ namespace cat {
     void setpuhargedHadronIso(float pu) {puChargedHadronIso_ = pu;} 
     
     // ID variables
-    void setIsPF(bool d) { isPF_ = d ; }
-    void setIsTight(bool d) { isTight_ = d; }
-    void setIsMedium(bool d) { isMedium_ = d; }
-    void setIsLoose(bool d) { isLoose_ = d; }
-    void setPassMVA(bool d) { passMVA_ = d; }
-    void setPassElectronVeto(bool pass){ passElVeto_ = pass;}
-    void setHasPixelSeed(bool hasPixSeed){hasPixSeed_ = hasPixSeed;}
+    void setIsPF(bool d) { idBits_[0] = d ; }
+    void setIsTight(bool d) { idBits_[1] = d; }
+    void setIsMedium(bool d) { idBits_[2] = d; }
+    void setIsLoose(bool d) { idBits_[3] = d; }
+    void setPassMVA(bool d) { idBits_[4] = d; }
+    void setPassElectronVeto(bool pass){ idBits_[5] = pass;}
+    void setHasPixelSeed(bool hasPixSeed){ idBits_[6] = hasPixSeed;}
 
     // Shower shape
     void setSigmaiEtaiEta(float ieteieta){ iEtaiEta_ = ieteieta;}
@@ -98,21 +98,14 @@ namespace cat {
 
     void setSmearedScale(const float scale) { smearedScale_ = scale; }
 
-    void setMCMatched(bool m) { mcMatched_ = m; }
+    void setMCMatched(bool m) { idBits_[7] = m; }
     
   private:
 
 
     std::vector<pat::Photon::IdPair> photonIDs_;
 
-    bool isPF_;
-    bool isTight_;
-    bool isMedium_;
-    bool isLoose_;
-    bool passMVA_;
-
-    bool passElVeto_;
-    bool hasPixSeed_;
+    std::bitset<8> idBits_; // isPF, isTight, isMedium, isLoose, passMVA, passElVeto, hasPixSeed, mcMatched
     
     float rhoIso_;
     float chargedHadronIso_;
@@ -126,9 +119,6 @@ namespace cat {
     float scEta_, scPhi_, scRawE_, scPreShE_;
 
     float smearedScale_;
-
-    bool mcMatched_;
-    
   };
 }
 

--- a/DataFormats/interface/SecVertex.h
+++ b/DataFormats/interface/SecVertex.h
@@ -65,8 +65,8 @@ namespace cat {
   private:
     float lxy_, l3D_, vProb_, dca_,dca2_,dca3_, cxPtHypot_, cxPtAbs_, jetDR_, legDR_ ,diffMass_;
     //int ipos_, ineg_;
-    int leptonID1_, trackQuality1_;
-    int leptonID2_, trackQuality2_;
+    char leptonID1_, trackQuality1_;
+    char leptonID2_, trackQuality2_;
     bool isMCMatch_;
 
   };

--- a/DataFormats/src/Electron.cc
+++ b/DataFormats/src/Electron.cc
@@ -4,6 +4,7 @@ using namespace cat;
 
 /// default constructor
 Electron::Electron() {
+  idBits_.reset();
 }
 
 Electron::Electron(const reco::LeafCandidate & aElectron) :
@@ -13,12 +14,10 @@ Electron::Electron(const reco::LeafCandidate & aElectron) :
   relIso04_(0),
   ipsig_(0),
   scEta_(0),
-  passConversionVeto_(false),
-  isGsfCtfScPixChargeConsistent_(false),
-  isEB_(false),
-  snuID_(0),
-  isTrigMVAValid_(false)
-{}
+  snuID_(0)
+{
+  idBits_.reset();
+}
 
 /// destructor
 Electron::~Electron() {

--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -24,6 +24,8 @@ GenTop::GenTop(){
   addbJetsHad_ = {null, null};
   addcJetsHad_ = {null, null};
   addJets_ = {null, null};
+
+  chBit_.reset();
 }
 
 // GenTop::GenTop(const reco::GenParticle & aGenTop) : reco::LeafCandidate(aGenTop) {
@@ -50,6 +52,8 @@ GenTop::GenTop(const reco::Candidate & aGenTop) : reco::LeafCandidate(aGenTop) {
   addbJetsHad_ = {null, null};
   addcJetsHad_ = {null, null};
   addJets_ = {null, null};
+
+  chBit_.reset();
 }
 
 /// destructor
@@ -60,6 +64,7 @@ GenTop::~GenTop() {
 void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenParticleCollection> genParticles, 
                       Handle<std::vector<int> > genBHadFlavour, Handle<std::vector<int> > genBHadJetIndex, 
                       Handle<std::vector<int> > genCHadFlavour, Handle<std::vector<int> > genCHadJetIndex){
+  chBit_.reset();
 
   math::XYZTLorentzVector null(0,0,0,0);
 
@@ -253,55 +258,42 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
      is2tops_=true;
   } else is2tops_ =false;
 
-  allHadronic_ = false;
-  semiLeptonic_ = false;
-  semiLeptonicEle_ = false;
-  semiLeptonicMuo_ = false;
-  semiLeptonicTau_ = false;
-  diLeptonic_ = false;
-  diLeptonicMuoMuo_ = false;
-  diLeptonicMuoEle_ = false;
-  diLeptonicEleEle_ = false;
-  diLeptonicTauMuo_ = false;
-  diLeptonicTauEle_ = false;
-  diLeptonicTauTau_ = false;
-
-  if ( hadronic[0] == true && hadronic[1] == true) allHadronic_ = true;
+  if ( hadronic[0] == true && hadronic[1] == true) chBit_[CHKeys::allHadronic] = true;
 
   if ( ( hadronic[0] == true &&  hadronic[1] == false ) ||
           ( hadronic[0] == false &&  hadronic[1] == true) )  {
     // All semi leptonic decays
-    semiLeptonic_ = true;
+    chBit_[CHKeys::semiLeptonic] = true;
     // Electron
     if ( ( hadronic[0] == true && electronic[1] == true) ||
-            ( hadronic[1] == true && electronic[0] == true ) )  semiLeptonicEle_ = true;
+            ( hadronic[1] == true && electronic[0] == true ) )  chBit_[CHKeys::semiLeptonicEle] = true;
     // Muon
     if ( ( hadronic[0] == true && muonic[1] == true ) ||
-            ( hadronic[1] == true && muonic[0] == true ) )  semiLeptonicMuo_ = true;
+            ( hadronic[1] == true && muonic[0] == true ) )  chBit_[CHKeys::semiLeptonicMuo] = true;
     // Tau
     if ( ( hadronic[0] == true && taunic[1] == true ) ||
-            ( hadronic[1] == true && taunic[0] == true ) )  semiLeptonicTau_ = true;
+            ( hadronic[1] == true && taunic[0] == true ) )  chBit_[CHKeys::semiLeptonicTau] = true;
   }
 
   // Di-Leptonic
   if ( hadronic[0] == false && hadronic[1] == false ) {
-    diLeptonic_ = true;
+    chBit_[CHKeys::diLeptonic] = true;
     // All di-leptonic decays
     // Electron-Electron
-    if ( electronic[0] == true && electronic[1] == true ) diLeptonicEleEle_ = true;
+    if ( electronic[0] == true && electronic[1] == true ) chBit_[CHKeys::diLeptonicEleEle] = true;
     // Muon-Muon
-    if ( muonic[0] == true && muonic[1] == true ) diLeptonicMuoMuo_ = true;
+    if ( muonic[0] == true && muonic[1] == true ) chBit_[CHKeys::diLeptonicMuoMuo] = true;
     // Electron-Muon
     if ( ( muonic[0] == true && electronic[1] == true ) ||
-      ( muonic[1] == true && electronic[0] == true ) )  diLeptonicMuoEle_ = true;
+      ( muonic[1] == true && electronic[0] == true ) )  chBit_[CHKeys::diLeptonicMuoEle] = true;
     // Tau-Muon
     if ( ( taunic[0] == true && muonic[1] == true ) ||
-      ( taunic[1] == true && muonic[0] == true ) )  diLeptonicTauMuo_ = true;
+      ( taunic[1] == true && muonic[0] == true ) )  chBit_[CHKeys::diLeptonicTauMuo] = true;
     // Tau-Electron
     if ( ( taunic[0] == true && electronic[1] == true ) ||
-      ( taunic[1] == true && electronic[0] == true ) ) diLeptonicTauEle_ = true;
+      ( taunic[1] == true && electronic[0] == true ) ) chBit_[CHKeys::diLeptonicTauEle] = true;
     // Tau-Tau
-    if ( taunic[0] == true && taunic[1] == true ) diLeptonicTauTau_ = true;
+    if ( taunic[0] == true && taunic[1] == true ) chBit_[CHKeys::diLeptonicTauTau] = true;
   }
 
   // debug
@@ -313,8 +305,8 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
   //cout << "diLeptonicTauEle= " << diLeptonicTauEle_ << endl;
   //cout << "diLeptonicTauTau= " << diLeptonicTauTau_ << endl;
 
-  taunic1_ = taunic[0];
-  taunic2_ = taunic[1];
+  chBit_[CHKeys::taunic1] = taunic[0];
+  chBit_[CHKeys::taunic2] = taunic[1];
 
   //sort b-quarks from top since the leading two quarks must be from top.
   std::sort(bquarksfromtop.begin(), bquarksfromtop.end(), GreaterByPt<reco::Candidate::LorentzVector>());

--- a/DataFormats/src/Jet.cc
+++ b/DataFormats/src/Jet.cc
@@ -11,9 +11,6 @@ Jet::Jet():
 
 Jet::Jet(const reco::LeafCandidate & aJet) :
   Particle( aJet ),
-  looseJetID_(false),
-  tightJetID_(false),
-  tightLepVetoJetID_(false),
   pileupJetId_(0),
   chargedEmEnergyFraction_(0),
   vtxMass_(0),
@@ -27,7 +24,9 @@ Jet::Jet(const reco::LeafCandidate & aJet) :
   shiftedEnUp_(1),					     
   fJER_(1), fJERUp_(1), fJERDown_(1),
   qgLikelihood_(-2)
-{}
+{
+  jetIdBits_.reset();
+}
 
 /// destructor
 Jet::~Jet() {

--- a/DataFormats/src/Lepton.cc
+++ b/DataFormats/src/Lepton.cc
@@ -8,10 +8,6 @@ Lepton::Lepton() {
 
 Lepton::Lepton(const reco::LeafCandidate & aLepton) :
   Particle( aLepton ),
-  isPF_(false),
-  isTight_(false),
-  isMedium_(false),
-  isLoose_(false),
   dz_(0),
   dxy_(0),
   chargedHadronIso03_(0),
@@ -22,9 +18,10 @@ Lepton::Lepton(const reco::LeafCandidate & aLepton) :
   puChargedHadronIso04_(0),
   neutralHadronIso04_(0),
   photonIso04_(0),
-  relMiniIso_(0),
-  mcMatched_(false)
-{}
+  relMiniIso_(0)
+{
+  idBits_.reset();
+}
 
 /// destructor
 Lepton::~Lepton() {

--- a/DataFormats/src/Muon.cc
+++ b/DataFormats/src/Muon.cc
@@ -7,8 +7,6 @@ Muon::Muon() {}
 
 Muon::Muon(const reco::LeafCandidate & aMuon) :
   Lepton( aMuon ),
-  isGlobalMuon_(false),
-  isSoftMuon_(false),
   normalizedChi2_(-1),
   ipsig_(-1),
   numberOfValidHits_(0),
@@ -16,7 +14,9 @@ Muon::Muon(const reco::LeafCandidate & aMuon) :
   numberOfMatchedStations_(0),
   numberOfValidPixelHits_(0),
   trackerLayersWithMeasurement_(0)
-{}
+{
+  idBits_.reset();
+}
 
 /// destructor
 Muon::~Muon() {

--- a/DataFormats/src/Photon.cc
+++ b/DataFormats/src/Photon.cc
@@ -8,13 +8,6 @@ Photon::Photon() {
 
 Photon::Photon(const reco::LeafCandidate & aPhoton) :
   Particle( aPhoton ),
-  isPF_(false),
-  isTight_(false),
-  isMedium_(false),
-  isLoose_(false),
-  passMVA_(false),
-  passElVeto_(false),
-  hasPixSeed_(false),
   rhoIso_(0),
   chargedHadronIso_(0),
   puChargedHadronIso_(0),
@@ -24,9 +17,10 @@ Photon::Photon(const reco::LeafCandidate & aPhoton) :
   r9_(0),
   HoverE_(0),
   scEta_(0), scPhi_(0), scRawE_(0), scPreShE_(0),
-  smearedScale_(1),
-  mcMatched_(false)
-{}
+  smearedScale_(1)
+{
+  idBits_.reset();
+}
 
 /// destructor
 Photon::~Photon() {

--- a/DataFormats/src/classes_def.xml
+++ b/DataFormats/src/classes_def.xml
@@ -100,4 +100,6 @@
 
   <class name="cat::TriggerNames" />
   <class name="edm::Wrapper<cat::TriggerNames>" />
+
+  <class pattern="std::bitset<*>" />
 </lcgdict>


### PR DESCRIPTION
Boolean flags can be packed into a std::bitset 
This allows file size reduction little bit, without information loss.

The reduction factor seem to be not that dramatic - overall 1.3% using inclusive ttbar sample.
GenTop object reduces by 3%(819Bytes/evt ->791Bytes/evt)  because this object has lots of boolean flags. (still not that significant)

Variable names will not be stored in the data structure, therefore if an analyzer open the catTuple without dataformat library can have trouble to decode the meaning of each bits.
But in the usual use-cases, I expect analyzers uses the full framework or at least FWLite to open the catTuples, therefore access to each flags are done with member function. 

catTuple from original v803
<pre>
$ edmEventSize -v catTuple.root  | grep CAT                            
catGenTops_catGenTops__CAT. 2818.83 818.742
catJets_catJets__CAT. 4037.31 759.17
catGenWeights_genWeight__CAT. 1062.62 718.735
catJets_catJetsPuppi__CAT. 1919.45 333.538
recoGenJets_pseudoTop_jets_CAT. 1469.35 287.696
catSecVertexs_catDstars_D0Cand_CAT. 783.121 258.9
patTriggerObjectStandAlones_catTrigger__CAT. 1809.56 252.99
catMuons_catMuons__CAT. 503.843 223.352
catElectrons_catElectrons__CAT. 1024.57 205.677
catPhotons_catPhotons__CAT. 636.574 150.08
catMETs_catMETsPuppi__CAT. 291.004 135.442
catMETs_catMETs__CAT. 290.154 132.784
catFatJets_catFatJets__CAT. 354.68 91.946
catSecVertexs_catDstars_DstarCand_CAT. 247.792 69.458
recoVertexs_catVertex__CAT. 150.782 60.186
recoGenParticles_pseudoTop_neutrinos_CAT. 183.6 44.476
catSecVertexs_catDstars_JpsiCand_CAT. 187.274 37.593
recoGenJets_pseudoTop_leptons_CAT. 142.011 37.376
recoGenParticles_pseudoTop__CAT. 162.312 34.543
catTriggerBits_catTrigger__CAT. 442.917 18.094
intss_genJetHadronFlavour_ancestors_CAT. 104.305 14.749
intss_genJetHadronFlavour_hadronAncestors_CAT. 69.133 10.419
ints_genJetHadronFlavour_nCHadron_CAT. 55.011 8.504
ints_genJetHadronFlavour_nBHadron_CAT. 55.011 7.812
edmTriggerResults_TriggerResults__CAT. 78.789 5.291
int_pileupWeight_nTrueInteraction_CAT. 7.245 3.271
float_pileupWeight_up_CAT. 7.085 3.223
float_pileupWeight_dn_CAT. 7.085 3.219
float_pileupWeight__CAT. 7.057 3.195
int_GenTtbarCategories_genTtbarId_CAT. 7.245 3.131
int_GenTtbarCategories30_genTtbarId_CAT. 7.273 3.131
int_GenTtbarCategories40_genTtbarId_CAT. 7.273 3.111
int_catVertex_nGoodPV_CAT. 7.077 3.087
int_catVertex_nPV_CAT. 7.021 3.051
bool_BadChargedCandidateFilter__CAT. 4.221 2.383
bool_BadPFMuonFilter__CAT. 4.081 2.243
</pre>

catTuple with bitset
<pre>
catGenTops_catGenTops__CAT. 2550.28 791.235
catJets_catJets__CAT. 3984.68 754.941
catGenWeights_genWeight__CAT. 1056.62 718.611
catJets_catJetsPuppi__CAT. 1886.91 329.727
recoGenJets_pseudoTop_jets_CAT. 1469.35 287.696
catSecVertexs_catDstars_D0Cand_CAT. 763.789 256.98
patTriggerObjectStandAlones_catTrigger__CAT. 1809.56 252.99
catMuons_catMuons__CAT. 473.697 215.334
catElectrons_catElectrons__CAT. 1028.06 199.14
catPhotons_catPhotons__CAT. 614.824 140.512
catMETs_catMETsPuppi__CAT. 291.004 135.442
catMETs_catMETs__CAT. 290.154 132.784
catFatJets_catFatJets__CAT. 349.85 90.412
catSecVertexs_catDstars_DstarCand_CAT. 245.824 69.394
recoVertexs_catVertex__CAT. 150.782 60.186
recoGenParticles_pseudoTop_neutrinos_CAT. 183.6 44.476
catSecVertexs_catDstars_JpsiCand_CAT. 187.19 37.609
recoGenJets_pseudoTop_leptons_CAT. 142.011 37.376
recoGenParticles_pseudoTop__CAT. 162.312 34.543
catTriggerBits_catTrigger__CAT. 442.917 18.094
intss_genJetHadronFlavour_ancestors_CAT. 104.305 14.749
intss_genJetHadronFlavour_hadronAncestors_CAT. 69.133 10.419
ints_genJetHadronFlavour_nCHadron_CAT. 55.011 8.504
ints_genJetHadronFlavour_nBHadron_CAT. 55.011 7.812
edmTriggerResults_TriggerResults__CAT. 78.789 5.291
int_pileupWeight_nTrueInteraction_CAT. 7.245 3.271
float_pileupWeight_up_CAT. 7.085 3.223
float_pileupWeight_dn_CAT. 7.085 3.219
float_pileupWeight__CAT. 7.057 3.195
int_GenTtbarCategories_genTtbarId_CAT. 7.245 3.131
int_GenTtbarCategories30_genTtbarId_CAT. 7.273 3.131
int_GenTtbarCategories40_genTtbarId_CAT. 7.273 3.111
int_catVertex_nGoodPV_CAT. 7.077 3.087
int_catVertex_nPV_CAT. 7.021 3.051
bool_BadChargedCandidateFilter__CAT. 4.221 2.383
bool_BadPFMuonFilter__CAT. 4.081 2.243
</pre>
