### PR TITLE
CatTrigger potential bugfix

### DIFF
--- a/CatAnalyzer/plugins/CATTriggerBitCombiner.cc
+++ b/CatAnalyzer/plugins/CATTriggerBitCombiner.cc
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <string>
+#include <iostream>
 
 class CATTriggerBitCombiner : public edm::stream::EDFilter<>
 {
@@ -50,6 +51,13 @@ bool CATTriggerBitCombiner::filter(edm::Event& event, const edm::EventSetup&)
 
   edm::Handle<cat::TriggerBits> trigBitsHandle;
   event.getByToken(trigBitsToken_, trigBitsHandle);
+
+  if ( trigNamesHandle->names().size() != trigBitsHandle->values().size() ) {
+    std::cout << "Inconsistent number of trig bits\n";
+    std::cout << "From names = " << trigNamesHandle->names().size() << '\n';
+    std::cout << "From bits  = " << trigBitsHandle->values().size() << '\n';
+    return false;
+  }
 
   // Keep trigger indices and ps factors
   std::vector<int> results;

--- a/DataFormats/interface/GenWeights.h
+++ b/DataFormats/interface/GenWeights.h
@@ -16,6 +16,7 @@ class GenWeightInfo {
 public:
   GenWeightInfo() {};
   virtual ~GenWeightInfo() {};
+  bool isProductEqual(const GenWeightInfo& other) const;
 
   typedef std::vector<float> vfloat;
   typedef std::vector<std::string> vstring;

--- a/DataFormats/interface/Trigger.h
+++ b/DataFormats/interface/Trigger.h
@@ -43,6 +43,7 @@ public:
 
   // Getters
   unsigned short result(const int i) const { return values_.at(i); } 
+  std::vector<unsigned short> values() const { return values_; }
 
 private:
   std::vector<unsigned short> values_;

--- a/DataFormats/src/GenWeights.cc
+++ b/DataFormats/src/GenWeights.cc
@@ -5,6 +5,29 @@
 using namespace std;
 using namespace cat;
 
+bool GenWeightInfo::isProductEqual(const GenWeightInfo& other) const
+{
+  if ( names_.size() != other.names_.size() ) return false;
+  if ( combineMethods_.size() != other.combineMethods_.size() ) return false;
+  if ( params_.size() != other.params_.size() ) return false;
+  if ( keys_.size() != other.keys_.size() ) return false;
+
+  for ( unsigned int i=0, n=names_.size(); i<n; ++i ) {
+    if ( names_[i] != other.names_[i] ) return false;
+  }
+  for ( unsigned int i=0, n=combineMethods_.size(); i<n; ++i ) {
+    if ( combineMethods_[i] != other.combineMethods_[i] ) return false;
+  }
+  for ( unsigned int i=0, n=params_.size(); i<n; ++i ) {
+    if ( params_[i] != other.params_[i] ) return false;
+  }
+  for ( unsigned int i=0, n=keys_.size(); i<n; ++i ) {
+    if ( keys_[i] != other.keys_[i] ) return false;
+  }
+
+  return true;
+}
+
 void GenWeightInfo::addWeightGroup(const string name, const string combineBy, const vector<string> params, const vector<unsigned short> keys)
 {
   names_.push_back(name);


### PR DESCRIPTION
The trigger name in the luminosity block and actual trigger bits seem to be inconsistent in some case, making some analyzer jobs to fail.

This PR solves the problem, trigger names are retrieved using the HLTConfigProvider at the beginLuminosityBlock function and stored in the event.
With this fix, analyzer modules can read CATTrigger objects produced on the fly.

The isProductEqual() function is implemented in the catGenWeight dataformat, to suppress warning message when reading multiple files.