### PR TITLE
Electron regression and smearing

### DIFF
--- a/CatProducer/python/patTools/egmRegression_cff.py
+++ b/CatProducer/python/patTools/egmRegression_cff.py
@@ -7,6 +7,12 @@ def enableElectronRegression(process):
     from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
     process = regressionWeights(process)
 
+    from EgammaAnalysis.ElectronTools.regressionWeights_local_cfi import GBRDWrapperRcd
+    GBRDWrapperRcd.connect = "sqlite_fip:EgammaAnalysis/ElectronTools/data/ged_regression_20170114.db"
+
+    process.regressions           = GBRDWrapperRcd
+    process.es_prefer_regressions = cms.ESPrefer('PoolDBESSource','regressions')
+
     process.load('EgammaAnalysis.ElectronTools.regressionApplication_cff')
 
     process.catElectrons.unsmaredElectrons = "slimmedElectrons::"+process.process

--- a/CatProducer/python/patTools/egmSmearing_cff.py
+++ b/CatProducer/python/patTools/egmSmearing_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 ## https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer
 
 def enableElectronSmearing(process, runOnMC=True):
-    process.load('EgammaAnalysis.ElectronTools.calibratedElectronsRun2_cfi')
+    process.load('EgammaAnalysis.ElectronTools.calibratedPatElectronsRun2_cfi')
 
     process.RandomNumberGeneratorService.calibratedPatElectrons = cms.PSet(
         initialSeed = cms.untracked.uint32(81),
@@ -17,7 +17,7 @@ def enableElectronSmearing(process, runOnMC=True):
     return process
 
 def enablePhotonSmearing(process, runOnMC=True):
-    process.load('EgammaAnalysis.ElectronTools.calibratedPhotonsRun2_cfi')
+    process.load('EgammaAnalysis.ElectronTools.calibratedPatPhotonsRun2_cfi')
 
     process.RandomNumberGeneratorService.calibratedPatPhotons = cms.PSet(
         initialSeed = cms.untracked.uint32(81),


### PR DESCRIPTION
Recipe to apply the electron regression and smearing changed after we implemented the v805 instruction.
Python configuration files are renamed in their head branch, subsequent prod jobs were not successful.
In addition, the string replacement using sed command in the previous CATTools recipe is removed by applying the same modification within the CATTools, CatProducer/python/patTools/egmRegression_cff.py.