### PR TITLE
lumi-weighted average of efficiency scale factor

### DIFF
--- a/CatAnalyzer/plugins/TtbarBbbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarBbbarDiLeptonAnalyzer.cc
@@ -80,10 +80,10 @@ private:
   {
     const int aid = abs(p.pdgId());
     if ( aid == 13 ) {
-      const double pt = p.pt(), aeta = std::abs(p.eta());
-      if      ( sys == +1 ) return muonSF_(pt, aeta,  1);
-      else if ( sys == -1 ) return muonSF_(pt, aeta, -1);
-      else return muonSF_(pt, aeta, 0);
+      const double pt = p.pt(), eta = p.eta();
+      if      ( sys == +1 ) return muonSF_(pt, eta,  1);
+      else if ( sys == -1 ) return muonSF_(pt, eta, -1);
+      else return muonSF_(pt, eta, 0);
     }
     return 1;
   }
@@ -349,13 +349,13 @@ TtbarBbbarDiLeptonAnalyzer::TtbarBbbarDiLeptonAnalyzer(const edm::ParameterSet& 
 
   const auto elecSFSet = iConfig.getParameter<edm::ParameterSet>("elecSF");
   elecSF_.set(elecSFSet.getParameter<std::vector<double>>("pt_bins"),
-              elecSFSet.getParameter<std::vector<double>>("abseta_bins"),
+              elecSFSet.getParameter<std::vector<double>>("eta_bins"),
               elecSFSet.getParameter<std::vector<double>>("values"),
               elecSFSet.getParameter<std::vector<double>>("errors"));
 
   const auto muonSFSet = iConfig.getParameter<edm::ParameterSet>("muonSF");
   muonSF_.set(muonSFSet.getParameter<std::vector<double>>("pt_bins"),
-              muonSFSet.getParameter<std::vector<double>>("abseta_bins"),
+              muonSFSet.getParameter<std::vector<double>>("eta_bins"),
               muonSFSet.getParameter<std::vector<double>>("values"),
               muonSFSet.getParameter<std::vector<double>>("errors"));
 

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -65,10 +65,10 @@ private:
   {
     const int aid = abs(p.pdgId());
     if ( aid == 13 ) {
-      const double pt = p.pt(), aeta = std::abs(p.eta());
-      if      ( sys == +1 ) return muonSF_(pt, aeta,  1);
-      else if ( sys == -1 ) return muonSF_(pt, aeta, -1);
-      else return muonSF_(pt, aeta, 0);
+      const double pt = p.pt(), eta = p.eta();
+      if      ( sys == +1 ) return muonSF_(pt, eta,  1);
+      else if ( sys == -1 ) return muonSF_(pt, eta, -1);
+      else return muonSF_(pt, eta, 0);
     }
     return 1;
   }
@@ -186,7 +186,7 @@ TtbarDiLeptonAnalyzer::TtbarDiLeptonAnalyzer(const edm::ParameterSet& iConfig)
   muonToken_ = consumes<cat::MuonCollection>(muonSet.getParameter<edm::InputTag>("src"));
   const auto muonSFSet = muonSet.getParameter<edm::ParameterSet>("effSF");
   muonSF_.set(muonSFSet.getParameter<vdouble>("pt_bins"),
-              muonSFSet.getParameter<vdouble>("abseta_bins"),
+              muonSFSet.getParameter<vdouble>("eta_bins"),
               muonSFSet.getParameter<vdouble>("values"),
               muonSFSet.getParameter<vdouble>("errors"));
 
@@ -194,7 +194,7 @@ TtbarDiLeptonAnalyzer::TtbarDiLeptonAnalyzer(const edm::ParameterSet& iConfig)
   elecToken_ = consumes<cat::ElectronCollection>(elecSet.getParameter<edm::InputTag>("src"));
   const auto elecSFSet = elecSet.getParameter<edm::ParameterSet>("effSF");
   elecSF_.set(elecSFSet.getParameter<vdouble>("pt_bins"),
-              elecSFSet.getParameter<vdouble>("abseta_bins"),
+              elecSFSet.getParameter<vdouble>("eta_bins"),
               elecSFSet.getParameter<vdouble>("values"),
               elecSFSet.getParameter<vdouble>("errors"));
 

--- a/CatAnalyzer/plugins/dileptonCommon.cc
+++ b/CatAnalyzer/plugins/dileptonCommon.cc
@@ -34,7 +34,7 @@ void dileptonCommon::parameterInit(const edm::ParameterSet& iConfig) {
   muonToken_ = consumes<cat::MuonCollection>(muonSet.getParameter<edm::InputTag>("src"));
   const auto muonSFSet = muonSet.getParameter<edm::ParameterSet>("effSF");
   muonSF_.set(muonSFSet.getParameter<vdouble>("pt_bins"),
-      muonSFSet.getParameter<vdouble>("abseta_bins"),
+      muonSFSet.getParameter<vdouble>("eta_bins"),
       muonSFSet.getParameter<vdouble>("values"),
       muonSFSet.getParameter<vdouble>("errors"));
 

--- a/CatAnalyzer/plugins/h2muAnalyzer.cc
+++ b/CatAnalyzer/plugins/h2muAnalyzer.cc
@@ -62,10 +62,10 @@ private:
   {
     const int aid = abs(p.pdgId());
     if ( aid == 13 ) {
-      const double pt = p.pt(), aeta = std::abs(p.eta());
-      if      ( sys == +1 ) return muonSF_(pt, aeta,  1);
-      else if ( sys == -1 ) return muonSF_(pt, aeta, -1);
-      else return muonSF_(pt, aeta, 0);
+      const double pt = p.pt(), eta = p.eta();
+      if      ( sys == +1 ) return muonSF_(pt, eta,  1);
+      else if ( sys == -1 ) return muonSF_(pt, eta, -1);
+      else return muonSF_(pt, eta, 0);
     }
     return 1;
   }
@@ -157,7 +157,7 @@ h2muAnalyzer::h2muAnalyzer(const edm::ParameterSet& iConfig)
   muonToken_ = consumes<cat::MuonCollection>(muonSet.getParameter<edm::InputTag>("src"));
   const auto muonSFSet = muonSet.getParameter<edm::ParameterSet>("effSF");
   muonSF_.set(muonSFSet.getParameter<vdouble>("pt_bins"),
-              muonSFSet.getParameter<vdouble>("abseta_bins"),
+              muonSFSet.getParameter<vdouble>("eta_bins"),
               muonSFSet.getParameter<vdouble>("values"),
               muonSFSet.getParameter<vdouble>("errors"));
 

--- a/CatAnalyzer/plugins/ttbbLepJetsAnalyzer.cc
+++ b/CatAnalyzer/plugins/ttbbLepJetsAnalyzer.cc
@@ -257,7 +257,7 @@ ttbbLepJetsAnalyzer::ttbbLepJetsAnalyzer(const edm::ParameterSet& iConfig):
   
   const auto muonSFSet = iConfig.getParameter<edm::ParameterSet>("muonSF");
   SF_muon_.set(muonSFSet.getParameter<std::vector<double>>("pt_bins"    ),
-	       muonSFSet.getParameter<std::vector<double>>("abseta_bins"),
+	       muonSFSet.getParameter<std::vector<double>>("eta_bins"),
 	       muonSFSet.getParameter<std::vector<double>>("values"     ),
 	       muonSFSet.getParameter<std::vector<double>>("errors"     ));
   
@@ -1077,9 +1077,9 @@ void ttbbLepJetsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
 
       if(isMC_) {
 	// Lepton SF (ID/ISO)
-	lepton_SF->push_back( SF_muon_( selectedMuons[0].pt(), std::abs(selectedMuons[0].eta()) ) );       // [0]-> SF
-	lepton_SF->push_back( SF_muon_( selectedMuons[0].pt(), std::abs(selectedMuons[0].eta()),  1.0 ) ); // [1]-> SF+Error
-	lepton_SF->push_back( SF_muon_( selectedMuons[0].pt(), std::abs(selectedMuons[0].eta()), -1.0 ) ); // [2]-> SF-Error
+	lepton_SF->push_back( SF_muon_( selectedMuons[0].pt(), selectedMuons[0].eta() ) );       // [0]-> SF
+	lepton_SF->push_back( SF_muon_( selectedMuons[0].pt(), selectedMuons[0].eta(),  1.0 ) ); // [1]-> SF+Error
+	lepton_SF->push_back( SF_muon_( selectedMuons[0].pt(), selectedMuons[0].eta(), -1.0 ) ); // [2]-> SF-Error
 	//LES
 	lepton_LES = selectedMuons[0].shiftedEn();
       }

--- a/CatAnalyzer/python/leptonSF_cff.py
+++ b/CatAnalyzer/python/leptonSF_cff.py
@@ -1,5 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
+def computeAverageSF(set1, lumi1, set2, lumi2):
+    sfSet = set1.clone()
+
+    w1 = lumi1/(lumi1+lumi2)
+    w2 = lumi2/(lumi1+lumi2)
+    for i in range(len(sfSet.values)):
+        ws1, ws2 = w1*set1.values[i], w2*set2.values[i]
+        sfSet.values[i] = ws1+ws2
+        sfSet.errors[i] = (ws1*ws1 + ws2*ws2)**0.5
+
+    return sfSet
+
 def combineSF(set1, set2, additionalUnc1=0, additionalUnc2=0):
     from bisect import bisect_right
 
@@ -75,6 +87,7 @@ dummySF = cms.PSet(
 ## Muon SF reference https://twiki.cern.ch/twiki/bin/view/CMS/MuonWorkInProgressAndPagResults
 ## SF for Run2016BCDE, before HIP issue
 muonSFTrackingOnly = cms.PSet(
+    pt_bins = cms.vdouble(10, 10000),
     eta_bins = cms.vdouble(-2.400000, -2.100000, -1.600000,-1.200000,-0.900000,-0.600000,-0.300000,-0.200000,0.200000,0.300000,0.600000,0.900000,1.200000,1.600000,2.100000,2.400000,),
     values = cms.vdouble(
         1.000085,
@@ -114,6 +127,7 @@ muonSFTrackingOnly = cms.PSet(
 
 ## SF for Run2016G-H, after HIP issue
 muonSFTrackingGHOnly = cms.PSet(
+    pt_bins = cms.vdouble(10, 10000),
     eta_bins = cms.vdouble(-2.400000, -2.100000, -1.600000,-1.200000,-0.900000,-0.600000,-0.300000,-0.200000,0.200000,0.300000,0.600000,0.900000,1.200000,1.600000,2.100000,2.400000,),
     values = cms.vdouble(
         0.982741,
@@ -442,7 +456,8 @@ electronSFCutBasedIDMediumWP74X = cms.PSet(
 
 ## Combined Scale factors
 ## id syst 1%+0.5%(quadrature), iso syst 1%
-muonSFTight = combineSF(muonSFTightIdOnly, muonSFTightIsoOnly, (0.01**2+0.005**2)**0.5, 0.01)
-muonSFTightGH = combineSF(muonSFTightGHIdOnly, muonSFTightGHIsoOnly, (0.01**2+0.005**2)**0.5, 0.01)
+muonSFTightBF = combineSF(combineSF(muonSFTightIdOnly, muonSFTightIsoOnly, (0.01**2+0.005**2)**0.5, 0.01), muonSFTrackingOnly)
+muonSFTightGH = combineSF(combineSF(muonSFTightGHIdOnly, muonSFTightGHIsoOnly, (0.01**2+0.005**2)**0.5, 0.01), muonSFTrackingGHOnly)
+muonSFTight = computeAverageSF(muonSFTightBF, 20.4, muonSFTightGH, 16.7)
 electronSFCutBasedIDMediumWP = combineSF(electronSFRecoOnly, electronSFCutBasedIDMediumWPIdOnly)
 

--- a/CatAnalyzer/python/leptonSF_cff.py
+++ b/CatAnalyzer/python/leptonSF_cff.py
@@ -6,9 +6,10 @@ def computeAverageSF(set1, lumi1, set2, lumi2):
     w1 = lumi1/(lumi1+lumi2)
     w2 = lumi2/(lumi1+lumi2)
     for i in range(len(sfSet.values)):
-        ws1, ws2 = w1*set1.values[i], w2*set2.values[i]
+        wv1, wv2 = w1*set1.values[i], w2*set2.values[i]
+        we1, we2 = w1*set1.errors[i], w2*set2.errors[i]
         sfSet.values[i] = ws1+ws2
-        sfSet.errors[i] = (ws1*ws1 + ws2*ws2)**0.5
+        sfSet.errors[i] = (we1*we1 + we2*we2)**0.5
 
     return sfSet
 

--- a/CatAnalyzer/python/leptonSF_cff.py
+++ b/CatAnalyzer/python/leptonSF_cff.py
@@ -8,7 +8,7 @@ def computeAverageSF(set1, lumi1, set2, lumi2):
     for i in range(len(sfSet.values)):
         wv1, wv2 = w1*set1.values[i], w2*set2.values[i]
         we1, we2 = w1*set1.errors[i], w2*set2.errors[i]
-        sfSet.values[i] = ws1+ws2
+        sfSet.values[i] = wv1+wv2
         sfSet.errors[i] = (we1*we1 + we2*we2)**0.5
 
     return sfSet

--- a/Validation/plugins/TTLJEventSelector.cc
+++ b/Validation/plugins/TTLJEventSelector.cc
@@ -308,7 +308,7 @@ TTLJEventSelector::TTLJEventSelector(const edm::ParameterSet& pset):
     const auto muonSFSet = muonSet.getParameter<edm::ParameterSet>("efficiencySF");
     // FIXME : for muons, eta bins are folded - always double check this with cfg
     muonSF_.set(muonSFSet.getParameter<vdouble>("pt_bins"),
-                muonSFSet.getParameter<vdouble>("abseta_bins"),
+                muonSFSet.getParameter<vdouble>("eta_bins"),
                 muonSFSet.getParameter<vdouble>("values"),
                 muonSFSet.getParameter<vdouble>("errors"));
     muonSFShift_ = muonSet.getParameter<int>("efficiencySFDirection");
@@ -545,7 +545,7 @@ bool TTLJEventSelector::filter(edm::Event& event, const edm::EventSetup&)
       if ( !isIgnoreTrig_ ) weight *= isTrigEl;
     }
     else if ( channel == 13 ) {
-      const double w1 = muonSF_(lepton1->pt(), std::abs(lepton1->eta()), muonSFShift_);
+      const double w1 = muonSF_(lepton1->pt(), lepton1->eta(), muonSFShift_);
       weight *= w1;
       if ( !isIgnoreTrig_ ) weight *= isTrigMu;
     }

--- a/Validation/plugins/TTLLEventSelector.cc
+++ b/Validation/plugins/TTLLEventSelector.cc
@@ -283,7 +283,7 @@ TTLLEventSelector::TTLLEventSelector(const edm::ParameterSet& pset):
     const auto muonSFSet = muonSet.getParameter<edm::ParameterSet>("efficiencySF");
     // FIXME : for muons, eta bins are folded - always double check this with cfg
     muonSF_.set(muonSFSet.getParameter<vdouble>("pt_bins"),
-                muonSFSet.getParameter<vdouble>("abseta_bins"),
+                muonSFSet.getParameter<vdouble>("eta_bins"),
                 muonSFSet.getParameter<vdouble>("values"),
                 muonSFSet.getParameter<vdouble>("errors"));
     muonSFShift_ = muonSet.getParameter<int>("efficiencySFDirection");
@@ -533,15 +533,15 @@ bool TTLLEventSelector::filter(edm::Event& event, const edm::EventSetup&)
       if ( !isIgnoreTrig_ ) weight *= isTrigElEl;
     }
     else if ( channel == CH_MUMU ) {
-      const double w1 = muonSF_(lepton1->pt(), std::abs(lepton1->eta()), muonSFShift_);
-      const double w2 = muonSF_(lepton2->pt(), std::abs(lepton2->eta()), muonSFShift_);
+      const double w1 = muonSF_(lepton1->pt(), lepton1->eta(), muonSFShift_);
+      const double w2 = muonSF_(lepton2->pt(), lepton2->eta(), muonSFShift_);
       weight *= w1*w2;
       if ( !isIgnoreTrig_ ) weight *= isTrigMuMu;
     }
     else if ( channel == CH_MUEL ) {
       const auto e1 = dynamic_cast<const cat::Electron*>(lepton1);
       const double w1 = electronSF_(lepton1->pt(), e1->scEta(), electronSFShift_);
-      const double w2 = muonSF_(lepton2->pt(), std::abs(lepton2->eta()), muonSFShift_);
+      const double w2 = muonSF_(lepton2->pt(), lepton2->eta(), muonSFShift_);
       weight *= w1*w2;
       if ( !isIgnoreTrig_ ) weight *= isTrigMuEl;
     }

--- a/Validation/plugins/TopFCNCEventSeletor.cc
+++ b/Validation/plugins/TopFCNCEventSeletor.cc
@@ -296,7 +296,7 @@ TopFCNCEventSelector::TopFCNCEventSelector(const edm::ParameterSet& pset):
     const auto muonSFSet = muonSet.getParameter<edm::ParameterSet>("efficiencySF");
     // FIXME : for muons, eta bins are folded - always double check this with cfg
     muonSF_.set(muonSFSet.getParameter<vdouble>("pt_bins"),
-                muonSFSet.getParameter<vdouble>("abseta_bins"),
+                muonSFSet.getParameter<vdouble>("eta_bins"),
                 muonSFSet.getParameter<vdouble>("values"),
                 muonSFSet.getParameter<vdouble>("errors"));
     muonSFShift_ = muonSet.getParameter<int>("efficiencySFDirection");
@@ -504,7 +504,7 @@ bool TopFCNCEventSelector::filter(edm::Event& event, const edm::EventSetup&)
   else if ( channel_ == 13 and !selMuons.empty() ) {
     const auto& mu = selMuons.at(0);
     lepton1 = &mu;
-    leptonSF = muonSF_(mu.pt(), std::abs(mu.eta()), muonSFShift_);
+    leptonSF = muonSF_(mu.pt(), mu.eta(), muonSFShift_);
   }
   int lepton1_id = 0;
   double lepton1_pt = -1, lepton1_eta = -999, lepton1_phi = -999;


### PR DESCRIPTION
The muon efficiency scale factors are splited by two periods, B-F/G-H datasets.
An weighted averaged scale factors are computed, with the luminosity of the periods.

The tracking efficiency SF are also combined in this PR.