### PR TITLE
Reduce event size for bkg MC

### DIFF
--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -10,6 +10,7 @@ options.register('runOnMC', True, VarParsing.multiplicity.singleton, VarParsing.
 options.register('useMiniAOD', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "useMiniAOD: 1  default")
 options.register('globalTag', '', VarParsing.multiplicity.singleton, VarParsing.varType.string, "globalTag: 1  default")
 options.register('runGenTop', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "runGenTop: 1  default")
+options.register('isSignal', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "isSignal: 1 default")
 
 options.parseArguments()
 runOnMC = options.runOnMC
@@ -17,6 +18,7 @@ useMiniAOD = options.useMiniAOD
 globalTag = options.globalTag
 if runOnMC: runGenTop = options.runGenTop
 else: runGenTop = False
+isMCSignal = (runOnMC and options.isSignal == True)
 
 ####################################################################
 #### setting up global tag
@@ -42,6 +44,10 @@ if runOnMC:
     process.load("CATTools.CatProducer.pileupWeight_cff")
     process.load("CATTools.CatProducer.producers.genWeight_cff")
     process.catOut.outputCommands.extend(catEventContentMC)
+
+    if isMCSignal:
+        process.genWeight.keepFirstOnly = False
+        process.catOut.outputCommands.extend(catEventContentMCSignal)
 else: 
     process.catOut.outputCommands.extend(catEventContentRD)
     

--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -9,8 +9,8 @@ options = VarParsing ('python')
 options.register('runOnMC', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "runOnMC: 1  default")
 options.register('useMiniAOD', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "useMiniAOD: 1  default")
 options.register('globalTag', '', VarParsing.multiplicity.singleton, VarParsing.varType.string, "globalTag: 1  default")
-options.register('runGenTop', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "runGenTop: 1  default")
-options.register('isSignal', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "isSignal: 1 default")
+options.register('runGenTop', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "runGenTop: 0  default")
+options.register('isSignal', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "isSignal: 0 default")
 
 options.parseArguments()
 runOnMC = options.runOnMC
@@ -57,8 +57,7 @@ if runGenTop:
     # for GenTtbarCategories
     from CATTools.CatProducer.Tools.tools import *
     genHFTool(process, useMiniAOD)
-    process.catOut.outputCommands.extend(['keep *_catGenTops_*_*',])
-            
+
 if doSecVertex:
     process.catOut.outputCommands.extend(catEventContentSecVertexs)
 

--- a/CatProducer/prod/PAT2CAT_cfg.py
+++ b/CatProducer/prod/PAT2CAT_cfg.py
@@ -9,8 +9,8 @@ options = VarParsing ('python')
 options.register('runOnMC', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "runOnMC: 1  default")
 options.register('useMiniAOD', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "useMiniAOD: 1  default")
 options.register('globalTag', '', VarParsing.multiplicity.singleton, VarParsing.varType.string, "globalTag: 1  default")
-options.register('runGenTop', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "runGenTop: 0  default")
-options.register('isSignal', False, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "isSignal: 0 default")
+options.register('runGenTop', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "runGenTop: 1  default")
+options.register('isSignal', True, VarParsing.multiplicity.singleton, VarParsing.varType.bool, "isSignal: 1 default")
 
 options.parseArguments()
 runOnMC = options.runOnMC

--- a/CatProducer/python/catEventContent_cff.py
+++ b/CatProducer/python/catEventContent_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 catEventContent = cms.untracked.vstring()
 catEventContentMC = cms.untracked.vstring()
 catEventContentRD = cms.untracked.vstring()
+catEventContentMCSignal = cms.untracked.vstring()
 catEventContentTOPMC = cms.untracked.vstring()
 catEventContentSecVertexs = cms.untracked.vstring()
 
@@ -33,7 +34,6 @@ catEventContentRD.extend([
     ])
 
 catEventContentMC.extend([
-    'keep recoGenParticles_prunedGenParticles_*_*',
     'keep *_slimmedGenJets_*_*',
     'keep *_genWeight_*_*',
     'keep *_pileupWeight*_*_*',
@@ -41,8 +41,11 @@ catEventContentMC.extend([
     #'keep *_matchGenCHadron_*_*',
     ])
 
+catEventContentMCSignal.extend([
+    'keep recoGenParticles_prunedGenParticles_*_*',
+    ])
+
 catEventContentTOPMC.extend([
-    'keep *_GenTtbarCategories_*_*',
     'keep *_GenTtbarCategories*_*_*',
     'keep *_catGenTops_*_*',
     #'keep *_partonTop_*_*', ## Can be built on the fly from prunedGenParticles

--- a/CatProducer/python/catEventContent_cff.py
+++ b/CatProducer/python/catEventContent_cff.py
@@ -26,7 +26,7 @@ catEventContent.extend([
     'keep patPackedTriggerPrescales_patTrigger__*', ## do we need this collection, where?
     'keep *_lumiMask*_*_*',
     'keep *_fixedGridRhoAll_*_', 'keep *_fixedGridRhoFastjetAll_*_*',
-    'keep *_BadChargedCandidateFilter_*_*', 'keep *_BadPFMuonFilter_*_*',
+    #'keep *_BadChargedCandidateFilter_*_*', 'keep *_BadPFMuonFilter_*_*',
     ])
 
 catEventContentRD.extend([
@@ -34,15 +34,15 @@ catEventContentRD.extend([
     ])
 
 catEventContentMC.extend([
-    'keep *_slimmedGenJets_*_*',
     'keep *_genWeight_*_*',
     'keep *_pileupWeight*_*_*',
-    #'keep *_matchGenBHadron_*_*',
-    #'keep *_matchGenCHadron_*_*',
     ])
 
 catEventContentMCSignal.extend([
+    'keep *_slimmedGenJets_*_*',
     'keep recoGenParticles_prunedGenParticles_*_*',
+    #'keep *_matchGenBHadron_*_*',
+    #'keep *_matchGenCHadron_*_*',
     ])
 
 catEventContentTOPMC.extend([

--- a/CatProducer/python/producers/genWeight_cff.py
+++ b/CatProducer/python/producers/genWeight_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 genWeight = cms.EDProducer("GenWeightsProducer",
     doLOPDFReweight = cms.bool(False),
     enforceUnitGenWeight = cms.bool(False),
-    keepFirstOnly = cms.bool(False),
+    keepFirstOnly = cms.bool(True),
     lheEvent = cms.InputTag("externalLHEProducer"),
     genEventInfo = cms.InputTag("generator"),
     pdfName = cms.string("NNPDF30_nlo_as_0118"),

--- a/CatProducer/python/producers/genWeight_cff.py
+++ b/CatProducer/python/producers/genWeight_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 genWeight = cms.EDProducer("GenWeightsProducer",
     doLOPDFReweight = cms.bool(False),
     enforceUnitGenWeight = cms.bool(False),
+    keepFirstOnly = cms.bool(False),
     lheEvent = cms.InputTag("externalLHEProducer"),
     genEventInfo = cms.InputTag("generator"),
     pdfName = cms.string("NNPDF30_nlo_as_0118"),

--- a/CatProducer/test/runtests.sh
+++ b/CatProducer/test/runtests.sh
@@ -2,33 +2,15 @@
 
 function die { echo $1: status $2 ;  exit $2; }
 
-INPUTFILE=`python <<EOF
-from CATTools.Validation.commonTestInput_cff import *
-print commonTestMiniAODs["bkg"][0]
-EOF
-`
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
-  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
-  "inputFiles=$INPUTFILE" \
+  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=0' 'isSignal=0' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
   || die 'Failure to run PAT2CAT from MiniAODSIM' $?
 
-INPUTFILE=`python <<EOF
-from CATTools.Validation.commonTestInput_cff import *
-print commonTestMiniAODs["sig"][0]
-EOF
-`
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
-  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
-  "inputFiles=$INPUTFILE" \
+  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'isSignal=1' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
   || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
 
-INPUTFILE=`python <<EOF
-from CATTools.Validation.commonTestInput_cff import *
-print commonTestMiniAODs["data"][0]
-EOF
-`
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
   'maxEvents=100' 'runOnMC=0' 'useMiniAOD=1' 'globalTag=80X_dataRun2_2016SeptRepro_v4' \
-  "inputFiles=$INPUTFILE" \
   || die 'Failure to run PAT2CAT from MiniAOD real data' $?
 


### PR DESCRIPTION
This PR reduces event size of catTuple for the bkg MCs.

A flag "isSignal" is added to drop genParticles in the output event content, also drop genWeights for the systematic uncertainty variations.

Deciding the "signal" and "background" definition is up to the users.

With this PR, we can save
- 785.628 Bytes/Event by dropping prunedGenParticles
- 326.873-28.752 = 298.121 Bytes/Event by keeping the nominal genWeight only

which is 20% of total size for the DY sample.
