### PR TITLE
Keep jet constituent pt/eta/phi

### DIFF
--- a/CatProducer/plugins/CATJetProducer.cc
+++ b/CatProducer/plugins/CATJetProducer.cc
@@ -205,6 +205,11 @@ void cat::CATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & i
     int partonPdgId = aPatJet.genParton() ? aPatJet.genParton()->pdgId() : 0;
     aJet.setPartonPdgId(partonPdgId);
 
+    for ( size_t i=0; i<aPatJet.numberOfDaughters(); ++i ) {
+      const auto p = aPatJet.daughter(i);
+      aJet.addConstituent(p->pt(), p->eta(), p->phi(), p->pdgId());
+    }
+
     // calculate quark/gluon likelihood but only for AK4
     aJet.setQGLikelihood(-2.0);
     if ( qgHandle.isValid() ) {

--- a/DataFormats/interface/Jet.h
+++ b/DataFormats/interface/Jet.h
@@ -8,7 +8,7 @@
 #include "DataFormats/PatCandidates/interface/JetCorrFactors.h"
 
 #include <string>
-#include <boost/array.hpp>
+#include <memory>
 
 // Define typedefs for convenience
 namespace cat {
@@ -136,9 +136,21 @@ namespace cat {
 
     void setQGLikelihood(float f) { qgLikelihood_ = f; }
 
+    void addConstituent(const float pt, const float eta, const float phi, const int pdgId) {
+      const int aid = abs(pdgId);
+      const std::array<float, 3> val = {{pt, eta, phi}};
+      if      ( aid == 211 ) con_ch_.emplace_back(val);
+      else if ( aid == 130 ) con_nh_.emplace_back(val);
+      else if ( aid == 22  ) con_ph_.emplace_back(val);
+    }
+    std::vector<std::array<float,3>> getConstituentCHsPtEtaPhi() { return con_ch_; }
+    std::vector<std::array<float,3>> getConstituentNHsPtEtaPhi() { return con_nh_; }
+    std::vector<std::array<float,3>> getConstituentPHsPtEtaPhi() { return con_ph_; }
+
   private:
 
     edm::FwdRef<reco::GenJetCollection>  genJetFwdRef_;
+    std::vector<std::array<float,3>> con_ch_, con_ph_, con_nh_;
 
     bool looseJetID_;
     bool tightJetID_;


### PR DESCRIPTION
This PR keeps jet constituents' pt,eta,phi in vector<array> to cover the jet imaging study.

Event size is expected to be increased with this change, but it should be better than saving all pf candidates.

Below are the size of cat::Jet before and after this update (x2 increase of cat::Jet)
```
        Uncompressed Compressed
Before       8585.63   1225.23
After        9978.81   2297.51
```
