### PR TITLE
9XY migration

### DIFF
--- a/CatAnalyzer/plugins/CATTriggerBitCombiner.cc
+++ b/CatAnalyzer/plugins/CATTriggerBitCombiner.cc
@@ -56,7 +56,7 @@ bool CATTriggerBitCombiner::filter(edm::Event& event, const edm::EventSetup&)
     std::cout << "Inconsistent number of trig bits\n";
     std::cout << "From names = " << trigNamesHandle->names().size() << '\n';
     std::cout << "From bits  = " << trigBitsHandle->values().size() << '\n';
-    event.put(std::auto_ptr<int>(new int(0)));
+    event.put(std::unique_ptr<int>(new int(0)));
     return false;
   }
 
@@ -92,7 +92,7 @@ bool CATTriggerBitCombiner::filter(edm::Event& event, const edm::EventSetup&)
   //   combine by and, anything not fired => 0
   //   combine by and, everything fired => ps1*ps2*...
 
-  event.put(std::auto_ptr<int>(new int(result)));
+  event.put(std::unique_ptr<int>(new int(result)));
 
   if ( !doFilter_ ) return true;
   return (result != 0);

--- a/CatAnalyzer/plugins/TTLLKinSolutionProducer.cc
+++ b/CatAnalyzer/plugins/TTLLKinSolutionProducer.cc
@@ -92,15 +92,15 @@ void TTLLKinSolutionProducer::beginLuminosityBlock(const edm::LuminosityBlock& l
 
 void TTLLKinSolutionProducer::produce(edm::Event& event, const edm::EventSetup&)
 {
-  std::auto_ptr<CandColl> cands(new CandColl);
+  std::unique_ptr<CandColl> cands(new CandColl);
   //auto candsRefProd = event.getRefBeforePut<CRCandColl>();
 
-  std::auto_ptr<floats> out_aux(new floats);
-  std::auto_ptr<floats> out_mLL(new floats);
-  std::auto_ptr<floats> out_mLB(new floats);
-  std::auto_ptr<floats> out_mAddJJ(new floats);
-  std::auto_ptr<floats> out_dphi(new floats);
-  std::auto_ptr<floats> out_quality(new floats);
+  std::unique_ptr<floats> out_aux(new floats);
+  std::unique_ptr<floats> out_mLL(new floats);
+  std::unique_ptr<floats> out_mLB(new floats);
+  std::unique_ptr<floats> out_mAddJJ(new floats);
+  std::unique_ptr<floats> out_dphi(new floats);
+  std::unique_ptr<floats> out_quality(new floats);
 
   std::vector<reco::CandidatePtr> leptons;
   edm::Handle<edm::View<reco::CandidatePtr> > leptonPtrHandle;
@@ -246,13 +246,13 @@ void TTLLKinSolutionProducer::produce(edm::Event& event, const edm::EventSetup&)
     }
   } while (false);
 
-  event.put(cands);
-  event.put(out_aux, "aux");
-  event.put(out_mLL, "mLL");
-  event.put(out_mLB, "mLB");
-  event.put(out_mAddJJ, "mAddJJ");
-  event.put(out_dphi, "dphi");
-  event.put(out_quality, "quality");
+  event.put(std::move(cands));
+  event.put(std::move(out_aux), "aux");
+  event.put(std::move(out_mLL), "mLL");
+  event.put(std::move(out_mLB), "mLB");
+  event.put(std::move(out_mAddJJ), "mAddJJ");
+  event.put(std::move(out_dphi), "dphi");
+  event.put(std::move(out_quality), "quality");
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/CatAnalyzer/plugins/TopPtWeightProducer.cc
+++ b/CatAnalyzer/plugins/TopPtWeightProducer.cc
@@ -42,7 +42,7 @@ void TopPtWeightProducer::produce(edm::Event& event, const edm::EventSetup& even
   edm::Handle<vint> modes;
   if ( event.isRealData() or
       !event.getByToken(srcToken_, srcHandle) or !event.getByToken(modesToken_, modes) ) {
-    event.put(std::auto_ptr<float>(new float(1)));
+    event.put(std::unique_ptr<float>(new float(1)));
     return;
   }
 
@@ -66,7 +66,7 @@ void TopPtWeightProducer::produce(edm::Event& event, const edm::EventSetup& even
     ptWeight = sqrt(exp(a+b*pt1)*exp(a+b*pt2));
   }
 
-  event.put(std::auto_ptr<float>(new float(ptWeight)));
+  event.put(std::unique_ptr<float>(new float(ptWeight)));
 }
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(TopPtWeightProducer);

--- a/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarDiLeptonAnalyzer.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/CatProducer/plugins/CATTriggerProducer.cc
+++ b/CatProducer/plugins/CATTriggerProducer.cc
@@ -123,7 +123,7 @@ void CATTriggerProducer::beginLuminosityBlockProduce(edm::LuminosityBlock& lumi,
     filterBits_[name] = 0;
   }
 
-  lumi.put(std::auto_ptr<cat::TriggerNames>(new cat::TriggerNames(filterBits_)));
+  lumi.put(std::unique_ptr<cat::TriggerNames>(new cat::TriggerNames(filterBits_)));
 }
 
 void CATTriggerProducer::produce(edm::Event& event, const edm::EventSetup&)

--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -219,7 +219,7 @@ GenWeightsProducer::GenWeightsProducer(const edm::ParameterSet& pset):
 
 void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
 {
-  std::auto_ptr<cat::GenWeightInfo> out_genWeightInfo(new cat::GenWeightInfo);
+  std::unique_ptr<cat::GenWeightInfo> out_genWeightInfo(new cat::GenWeightInfo);
 
   do {
     // Workaround found in HN, physicstools #3437
@@ -285,7 +285,7 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
 
   } while ( false );
 
-  run.put(out_genWeightInfo);
+  run.put(std::move(out_genWeightInfo));
 }
 
 void GenWeightsProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup)

--- a/CatProducer/python/catCandidates_cff.py
+++ b/CatProducer/python/catCandidates_cff.py
@@ -1,15 +1,84 @@
 import FWCore.ParameterSet.Config as cms
+from CATTools.CatProducer.catEventContent_cff import *
 
-from CATTools.CatProducer.producers.muonProducer_cfi import *
-from CATTools.CatProducer.producers.electronProducer_cfi import *
-from CATTools.CatProducer.producers.photonProducer_cfi import *
-from CATTools.CatProducer.producers.jetProducer_cfi import *
-from CATTools.CatProducer.producers.fatjetProducer_cfi import *
-from CATTools.CatProducer.producers.metProducer_cfi import *
-from CATTools.CatProducer.producers.tauProducer_cfi import *
-from CATTools.CatProducer.producers.secondaryVertexProducer_cfi import *
-from CATTools.CatProducer.producers.dstarProducer_cfi import *
-from CATTools.CatProducer.producers.vertexProducer_cfi import *
-from CATTools.CatProducer.producers.triggerProducer_cfi import *
-from CATTools.CatProducer.producers.genTopProducer_cfi import * #please do not remove it.
-from CATTools.CatProducer.producers.genJetHadronMatch_cfi import *
+def addCatCommonObjects(process):
+    process.load("CATTools.CatProducer.producers.triggerProducer_cfi")
+    process.load("CATTools.CatProducer.producers.vertexProducer_cfi")
+
+    process.load("CATTools.CatProducer.producers.muonProducer_cfi")
+    process.load("CATTools.CatProducer.producers.electronProducer_cfi")
+    process.load("CATTools.CatProducer.producers.jetProducer_cfi")
+    process.load("CATTools.CatProducer.producers.metProducer_cfi")
+
+    process.load("CATTools.CatProducer.producers.photonProducer_cfi")
+    process.load("CATTools.CatProducer.producers.tauProducer_cfi")
+    process.load("CATTools.CatProducer.producers.fatjetProducer_cfi")
+
+    process.RandomNumberGeneratorService.catJets = cms.PSet(
+        engineName = cms.untracked.string('TRandom3'),
+        initialSeed = cms.untracked.uint32(1),
+    )
+    process.RandomNumberGeneratorService.catFatJets = cms.PSet(
+        engineName = cms.untracked.string('TRandom3'),
+        initialSeed = cms.untracked.uint32(1),
+    )
+    process.RandomNumberGeneratorService.catJetsPuppi = cms.PSet(
+        engineName = cms.untracked.string('TRandom3'),
+        initialSeed = cms.untracked.uint32(1),
+    )
+
+    process.catOut.outputCommands.extend(catEventContent)
+    process.catObjectTask.add(
+        process.catTrigger, process.catVertex,
+        process.catMuons, process.catElectrons, process.catJets, process.catMETs,
+        process.catPhotons, process.catTaus, process.catFatJets,
+    )
+    return process
+
+def addCatCommonMCObjects(process):
+    process.load("CATTools.CatProducer.pileupWeight_cff")
+    process.load("CATTools.CatProducer.producers.genWeight_cff")
+
+    process.catOut.outputCommands.extend(catEventContentMC)
+    process.catObjectTask.add(
+        process.pileupWeight, process.genWeight
+    )
+
+    return process
+
+def addCatSecVertexObjects(process):
+    process.load("CATTools.CatProducer.producers.secondaryVertexProducer_cfi")
+
+    process.catOut.outputCommands.extend(catEventContentSecVertexs)
+    process.catObjectTask.add(
+        process.catSecVertexs
+    )
+    return process
+
+def addCatDstarObjects(process):
+    process.load("CATTools.CatProducer.producers.dstarProducer_cfi")
+
+    process.catOut.outputCommands.extend(['keep *_catDstars_*_*',])
+    process.catObjectTask.add(
+        process.catDstars
+    )
+    return process
+
+def addCatGenTopObjects(process):
+    process.load("CATTools.CatProducer.producers.genTopProducer_cfi") #please do not remove it.
+    process.load("CATTools.CatProducer.producers.genJetHadronMatch_cfi")
+    process.load("TopQuarkAnalysis.TopTools.GenTtbarCategorizer_cfi")
+
+    # for GenTtbarCategories
+    from CATTools.CatProducer.Tools.tools import getHFTool
+    genHFTool(process, True)
+    process.catOut.outputCommands.extend(catEventContentTOPMC)
+    process.catObjectTask.add(
+        process.catGenTops
+    )
+    return process
+
+def addCatParticleTopObjects(process):
+    process.load("CATTools.CatProducer.mcTruthTop.particleTop_cff")
+    process.catOut.outputCommands.extend(catEventContentTOPParticleLevel)
+    return process

--- a/CatProducer/python/catEventContent_cff.py
+++ b/CatProducer/python/catEventContent_cff.py
@@ -9,7 +9,6 @@ catEventContentSecVertexs = cms.untracked.vstring()
 catEventContentTOPParticleLevel = cms.untracked.vstring()
 
 catEventContent.extend([
-    'drop *',
     'keep *_nEventsTotal_*_*',
     'keep *_nEventsFiltered_*_*',
     'keep *_catMuons_*_*',
@@ -28,10 +27,6 @@ catEventContent.extend([
     'keep *_lumiMask*_*_*',
     'keep *_fixedGridRhoAll_*_', 'keep *_fixedGridRhoFastjetAll_*_*',
     #'keep *_BadChargedCandidateFilter_*_*', 'keep *_BadPFMuonFilter_*_*',
-    ])
-
-catEventContentRD.extend([
-    'keep *_lumiMask*_*_*',
     ])
 
 catEventContentMC.extend([

--- a/CatProducer/python/catTemplate_cfg.py
+++ b/CatProducer/python/catTemplate_cfg.py
@@ -37,5 +37,10 @@ process.catOut = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('catTuple.root'),
     outputCommands = cms.untracked.vstring('drop *')
 )
+process.catOutPath = cms.EndPath(process.catOut)
+process.catObjectTask = cms.Task()
+process.schedule = cms.Schedule(
+    process.p, process.catOutPath,
+    tasks = process.catObjectTask
+)
 
-process.schedule = cms.Schedule()

--- a/CatProducer/python/catTemplate_cfg.py
+++ b/CatProducer/python/catTemplate_cfg.py
@@ -18,7 +18,6 @@ from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 
 ## Options and Output Report
 process.options = cms.untracked.PSet(
-    allowUnscheduled = cms.untracked.bool(True),
     wantSummary = cms.untracked.bool(True)
 )
 
@@ -39,4 +38,4 @@ process.catOut = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring('drop *')
 )
 
-process.schedule = cms.Schedule()    
+process.schedule = cms.Schedule()

--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -15,7 +15,7 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         process.lumiMask = cms.EDFilter("LumiMaskFilter",
             LumiSections = LumiList('%s/src/CATTools/CatProducer/data/LumiMask/%s.txt'%(os.environ['CMSSW_BASE'], cat.lumiJSON)).getVLuminosityBlockRange())
 
-        process.load("CATTools.CatProducer.eventCleaning.badECALSlewRateMitigationFilter2016_cfi")
+        #process.load("CATTools.CatProducer.eventCleaning.badECALSlewRateMitigationFilter2016_cfi")
     
     useJECfile = True
     jecFiles = cat.JetEnergyCorrection
@@ -84,21 +84,6 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         process.catJetsPuppi.src = cms.InputTag("patJetsPuppiUpdated")
         process.catJetsPuppi.setGenParticle = cms.bool(False)
         ## #######################################################################
-        ## Setup JER
-        ## JER needs random numbers
-        process.RandomNumberGeneratorService.catJets = cms.PSet(
-            engineName = cms.untracked.string('TRandom3'),
-            initialSeed = cms.untracked.uint32(1),
-        )
-        process.RandomNumberGeneratorService.catFatJets = cms.PSet(
-            engineName = cms.untracked.string('TRandom3'),
-            initialSeed = cms.untracked.uint32(1),
-        )
-        process.RandomNumberGeneratorService.catJetsPuppi = cms.PSet(
-            engineName = cms.untracked.string('TRandom3'),
-            initialSeed = cms.untracked.uint32(1),
-        )
-
         ## qg-likelihood
         # check https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
         from CATTools.CatProducer.patTools.jetQGLikelihood_cff import enableQGLikelihood
@@ -114,18 +99,18 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         runMetCorAndUncFromMiniAOD(process, isData= not runOnMC, electronColl=cms.InputTag('calibratedPatElectrons'))
         process.catMETs.src = cms.InputTag("slimmedMETs","","CAT")
 
-        from CATTools.CatProducer.patTools.metMuonRecoMitigation2016_cff import enableMETMuonRecoMitigation2016
-        process = enableMETMuonRecoMitigation2016(process, runOnMC) ## MET input object is overridden in the modifier function
+        #from CATTools.CatProducer.patTools.metMuonRecoMitigation2016_cff import enableMETMuonRecoMitigation2016
+        #process = enableMETMuonRecoMitigation2016(process, runOnMC) ## MET input object is overridden in the modifier function
 
         #######################################################################
         ## Electron regression
-        from CATTools.CatProducer.patTools.egmRegression_cff import enableElectronRegression
-        process = enableElectronRegression(process)
+        #from CATTools.CatProducer.patTools.egmRegression_cff import enableElectronRegression
+        #process = enableElectronRegression(process)
 
         ## Energy/Photon smearing and scale correction
-        from CATTools.CatProducer.patTools.egmSmearing_cff import enableElectronSmearing, enablePhotonSmearing
-        process = enableElectronSmearing(process, runOnMC)
-        process = enablePhotonSmearing(process, runOnMC)
+        #from CATTools.CatProducer.patTools.egmSmearing_cff import enableElectronSmearing, enablePhotonSmearing
+        #process = enableElectronSmearing(process, runOnMC)
+        #process = enablePhotonSmearing(process, runOnMC)
         
         ## Electron/Photon VID
         from CATTools.CatProducer.patTools.egmVersionedID_cff import enableElectronVID, enablePhotonVID

--- a/CatProducer/python/patTools/jetDeepFlavour_cff.py
+++ b/CatProducer/python/patTools/jetDeepFlavour_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 # https://twiki.cern.ch/twiki/bin/view/CMS/DeepFlavour
 
-from CondCore.DBCommon.CondDBSetup_cfi import *
+from CondCore.CondDB.CondDB_cfi import *
 def enableDeepFlavour(process):
     process.load("RecoBTag.Combined.deepFlavour_cff")
 

--- a/CatProducer/python/patTools/jetQGLikelihood_cff.py
+++ b/CatProducer/python/patTools/jetQGLikelihood_cff.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 # https://twiki.cern.ch/twiki/bin/viewauth/CMS/QuarkGluonLikelihood
 # https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
 
-from CondCore.DBCommon.CondDBSetup_cfi import *
+from CondCore.CondDB.CondDB_cfi import *
 def enableQGLikelihood(process, qgDatabaseVersion='v2b', runOnMC=True, useMiniAOD=True):
 
     process.QGPoolDBESSource = cms.ESSource("PoolDBESSource",
-        CondDBSetup,
+        CondDB,
         toGet = cms.VPSet(),
         #connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
         connect = cms.string('sqlite_fip:CATTools/CatProducer/data/QGL_%s.db' % qgDatabaseVersion),

--- a/CatProducer/python/patTools/metFilters_cff.py
+++ b/CatProducer/python/patTools/metFilters_cff.py
@@ -12,9 +12,6 @@ def enableAdditionalMETFilters(process, runOnMC=True):
     process.BadChargedCandidateFilter.muons = cms.InputTag("slimmedMuons")
     process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidates")
  
-    if not hasattr(process, 'nEventsFiltered'):
-        process.nEventsFiltered = cms.EDProducer("EventCountProducer")
-        process.p += process.nEventsFiltered
-    process.p += (process.BadPFMuonFilter*process.BadChargedCandidateFilter*process.nEventsFiltered)
+    process.p += (process.BadPFMuonFilter*process.BadChargedCandidateFilter)
 
     return process

--- a/CatProducer/python/patTools/patTools_cff.py
+++ b/CatProducer/python/patTools/patTools_cff.py
@@ -18,4 +18,5 @@ def patTool(process, runOnMC=True, useMiniAOD = True):
         
         process.patJetsPuppi.embedGenPartonMatch = cms.bool(False)
         process.patJetCorrFactorsPuppi.useRho = cms.bool(False)
-    process.schedule.append(process.p)
+
+    return process

--- a/CatProducer/python/producers/triggerProducer_cfi.py
+++ b/CatProducer/python/producers/triggerProducer_cfi.py
@@ -6,7 +6,7 @@ catTrigger = cms.EDProducer("CATTriggerProducer",
 #            cms.InputTag("TriggerResults","","HLT2"),# due to reHLT, this is the first choice
             cms.InputTag("TriggerResults","","HLT"),# if above is not found, falls to default
         ),
-        objects = cms.InputTag("selectedPatTrigger"),
+        objects = cms.InputTag("slimmedPatTrigger"),
         prescales = cms.InputTag("patTrigger"),
         prefix = cms.vstring(
             "HLT_Ele", "HLT_DoubleEle",

--- a/CatProducer/test/runtests.sh
+++ b/CatProducer/test/runtests.sh
@@ -2,15 +2,15 @@
 
 function die { echo $1: status $2 ;  exit $2; }
 
-cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
-  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=0' 'isSignal=0' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
-  || die 'Failure to run PAT2CAT from MiniAODSIM' $?
+#cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
+#  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=0' 'isSignal=0' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
+#  || die 'Failure to run PAT2CAT from MiniAODSIM' $?
+#
+#cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
+#  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'isSignal=1' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
+#  || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
 
 cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
-  'maxEvents=100' 'runOnMC=1' 'useMiniAOD=1' 'runGenTop=1' 'isSignal=1' 'globalTag=80X_mcRun2_asymptotic_2016_TrancheIV_v6' \
-  || die 'Failure to run PAT2CAT from MiniAODSIM + GenTop' $?
-
-cmsRun ${LOCAL_TEST_DIR}/../prod/PAT2CAT_cfg.py \
-  'maxEvents=100' 'runOnMC=0' 'useMiniAOD=1' 'globalTag=80X_dataRun2_2016SeptRepro_v4' \
+  'maxEvents=100' 'runOnMC=0' 'useMiniAOD=1' 'globalTag=92X_dataRun2_Prompt_v11' \
   || die 'Failure to run PAT2CAT from MiniAOD real data' $?
 

--- a/Validation/plugins/TTLJEventSelector.cc
+++ b/Validation/plugins/TTLJEventSelector.cc
@@ -429,9 +429,9 @@ bool TTLJEventSelector::filter(edm::Event& event, const edm::EventSetup&)
   event.getByToken(nVertexToken_, nVertexHandle);
   const int nVertex = *nVertexHandle;
 
-  std::auto_ptr<std::vector<cat::Electron> > out_electrons(new std::vector<cat::Electron>());
-  std::auto_ptr<std::vector<cat::Muon> > out_muons(new std::vector<cat::Muon>());
-  std::auto_ptr<std::vector<cat::Jet> > out_jets(new std::vector<cat::Jet>());
+  std::unique_ptr<std::vector<cat::Electron> > out_electrons(new std::vector<cat::Electron>());
+  std::unique_ptr<std::vector<cat::Muon> > out_muons(new std::vector<cat::Muon>());
+  std::unique_ptr<std::vector<cat::Jet> > out_jets(new std::vector<cat::Jet>());
 
   // Compute event weight - from generator, pileup, etc
   double weight = 1.0;
@@ -840,14 +840,14 @@ bool TTLJEventSelector::filter(edm::Event& event, const edm::EventSetup&)
     }
   }
 
-  event.put(std::auto_ptr<int>(new int(cutstep)), "cutstep");
-  event.put(std::auto_ptr<int>(new int((int)channel)), "channel");
-  event.put(std::auto_ptr<float>(new float(weight)), "weight");
-  event.put(std::auto_ptr<float>(new float(metP4.pt())), "met");
-  event.put(std::auto_ptr<float>(new float(metP4.phi())), "metphi");
-  event.put(out_electrons, "electrons");
-  event.put(out_muons, "muons");
-  event.put(out_jets, "jets");
+  event.put(std::unique_ptr<int>(new int(cutstep)), "cutstep");
+  event.put(std::unique_ptr<int>(new int((int)channel)), "channel");
+  event.put(std::unique_ptr<float>(new float(weight)), "weight");
+  event.put(std::unique_ptr<float>(new float(metP4.pt())), "met");
+  event.put(std::unique_ptr<float>(new float(metP4.phi())), "metphi");
+  event.put(std::move(out_electrons), "electrons");
+  event.put(std::move(out_muons), "muons");
+  event.put(std::move(out_jets), "jets");
 
   // Apply filter at the given step.
   if ( cutstep >= applyFilterAt_ ) return true;

--- a/Validation/plugins/TTLLEventSelector.cc
+++ b/Validation/plugins/TTLLEventSelector.cc
@@ -405,9 +405,9 @@ bool TTLLEventSelector::filter(edm::Event& event, const edm::EventSetup&)
   event.getByToken(nVertexToken_, nVertexHandle);
   const int nVertex = *nVertexHandle;
 
-  std::auto_ptr<std::vector<cat::Electron> > out_electrons(new std::vector<cat::Electron>());
-  std::auto_ptr<std::vector<cat::Muon> > out_muons(new std::vector<cat::Muon>());
-  std::auto_ptr<std::vector<cat::Jet> > out_jets(new std::vector<cat::Jet>());
+  std::unique_ptr<std::vector<cat::Electron> > out_electrons(new std::vector<cat::Electron>());
+  std::unique_ptr<std::vector<cat::Muon> > out_muons(new std::vector<cat::Muon>());
+  std::unique_ptr<std::vector<cat::Jet> > out_jets(new std::vector<cat::Jet>());
 
   // Compute event weight - from generator, pileup, etc
   double weight = 1.0;
@@ -831,14 +831,14 @@ bool TTLLEventSelector::filter(edm::Event& event, const edm::EventSetup&)
     }
   }
 
-  event.put(std::auto_ptr<int>(new int(cutstep)), "cutstep");
-  event.put(std::auto_ptr<int>(new int((int)channel)), "channel");
-  event.put(std::auto_ptr<float>(new float(weight)), "weight");
-  event.put(std::auto_ptr<float>(new float(metP4.pt())), "met");
-  event.put(std::auto_ptr<float>(new float(metP4.phi())), "metphi");
-  event.put(out_electrons, "electrons");
-  event.put(out_muons, "muons");
-  event.put(out_jets, "jets");
+  event.put(std::unique_ptr<int>(new int(cutstep)), "cutstep");
+  event.put(std::unique_ptr<int>(new int((int)channel)), "channel");
+  event.put(std::unique_ptr<float>(new float(weight)), "weight");
+  event.put(std::unique_ptr<float>(new float(metP4.pt())), "met");
+  event.put(std::unique_ptr<float>(new float(metP4.phi())), "metphi");
+  event.put(std::move(out_electrons), "electrons");
+  event.put(std::move(out_muons), "muons");
+  event.put(std::move(out_jets), "jets");
 
   // Apply filter at the given step.
   if ( cutstep >= applyFilterAt_ ) return true;

--- a/Validation/plugins/TopFCNCEventSeletor.cc
+++ b/Validation/plugins/TopFCNCEventSeletor.cc
@@ -428,9 +428,9 @@ bool TopFCNCEventSelector::filter(edm::Event& event, const edm::EventSetup&)
   // use the side-effect of catVertex producer: pv collection size == 1 only if the pv[0] is good vtx
   const bool isGoodPV0 = (nGoodVertex >= 1 and vertexHandle->size() == 1);
 
-  std::auto_ptr<std::vector<cat::Electron> > out_electrons(new std::vector<cat::Electron>());
-  std::auto_ptr<std::vector<cat::Muon> > out_muons(new std::vector<cat::Muon>());
-  std::auto_ptr<std::vector<cat::Jet> > out_jets(new std::vector<cat::Jet>());
+  std::unique_ptr<std::vector<cat::Electron> > out_electrons(new std::vector<cat::Electron>());
+  std::unique_ptr<std::vector<cat::Muon> > out_muons(new std::vector<cat::Muon>());
+  std::unique_ptr<std::vector<cat::Jet> > out_jets(new std::vector<cat::Jet>());
 
   // Compute event weight - from generator, pileup, etc
   float weight = 1.0;
@@ -658,14 +658,14 @@ bool TopFCNCEventSelector::filter(edm::Event& event, const edm::EventSetup&)
     }
   }
 
-  event.put(std::auto_ptr<int>(new int(cutstep)), "cutstep");
-  event.put(std::auto_ptr<int>(new int((int)channel_)), "channel");
-  event.put(std::auto_ptr<float>(new float(weight)), "weight");
-  event.put(std::auto_ptr<float>(new float(met_pt)), "met");
-  event.put(std::auto_ptr<float>(new float(met_phi)), "metphi");
-  event.put(out_electrons, "electrons");
-  event.put(out_muons, "muons");
-  event.put(out_jets, "jets");
+  event.put(std::unique_ptr<int>(new int(cutstep)), "cutstep");
+  event.put(std::unique_ptr<int>(new int((int)channel_)), "channel");
+  event.put(std::unique_ptr<float>(new float(weight)), "weight");
+  event.put(std::unique_ptr<float>(new float(met_pt)), "met");
+  event.put(std::unique_ptr<float>(new float(met_phi)), "metphi");
+  event.put(std::move(out_electrons), "electrons");
+  event.put(std::move(out_muons), "muons");
+  event.put(std::move(out_jets), "jets");
 
   // Apply filter at the given step.
   // "cutstep" variable is set to the failed cut step when exiting the previous loop.

--- a/Validation/python/commonTestInput_cff.py
+++ b/Validation/python/commonTestInput_cff.py
@@ -12,8 +12,12 @@ commonTestCATTuples804 = {
     "data":cms.untracked.vstring("/store/group/CAT/DoubleEG/v8-0-4_Run2016H-PromptReco-v3/170113_133053/0000/catTuple_1.root"),
 }
 
-commonTestMiniAODs = {
+commonTestMiniAODs80X = {
     "sig":cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv2/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/0693E0E7-97BE-E611-B32F-0CC47A78A3D8.root",),
     "bkg":cms.untracked.vstring("/store/mc/RunIISummer16MiniAODv2/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext2-v1/50000/005CDFA8-48D6-E611-A10D-FA163E944599.root",),
     "data":cms.untracked.vstring("/store/data/Run2016H/SingleMuon/MINIAOD/03Feb2017_ver2-v1/80000/002F0CF2-C7EA-E611-9759-0025904C7F5C.root",),
+}
+
+commonTestMiniAODs = {
+    "data":cms.untracked.vstring("root://cms-xrd-global.cern.ch//store/data/Run2017H/SingleMuon/MINIAOD/PromptReco-v1/000/306/896/00000/E6B313CF-55D0-E711-A7D0-02163E019CCB.root",),
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,48 +1,17 @@
-scram project -n cattools CMSSW_8_0_29
+scram project -n cattools CMSSW_9_1_14_patch2
 cd cattools/src
 cmsenv
 git-cms-init -q
-git checkout -b cat80x
+git checkout -b cat90x
 
-git-cms-addpkg RecoEgamma/ElectronIdentification
-git-cms-addpkg EgammaAnalysis/ElectronTools
-git-cms-addpkg RecoMET/METFilters
-git-cms-addpkg RecoBTag/DeepFlavour
-
-sed -i 's/badGlobalMuonTagger.clone/badGlobalMuonTaggerMAOD.clone/g' RecoMET/METFilters/python/badGlobalMuonTaggersMiniAOD_cff.py
-
-#brings in HEEP V70 into VID
-git cms-merge-topic -u Sam-Harper:HEEPV70VID_8010_ReducedCheckout
-
-#for other E/gamma IDs in VID if you wish to have them
-git cms-merge-topic -u ikrav:egm_id_80X_v3
-
-#only necessary to run HEEP V70 on AOD
-git cms-merge-topic -u Sam-Harper:PackedCandNoPuppi 
-git-cms-merge-topic -u cms-egamma:EGM_gain_v1
-git-cms-merge-topic -u ikrav:egm_id_80X_v3_photons
-
-cd EgammaAnalysis/ElectronTools/data
-wget https://github.com/cms-egamma/RegressionDatabase/blob/master/SQLiteFiles/GED_80X_Winter2016/ged_regression_20170114.db?raw=true -O ged_regression_20170114.db
-git clone -b Moriond17_gainSwitch_unc https://github.com/ECALELFS/ScalesSmearings.git
-cd ../../..
-
-mkdir -p RecoBTag/DeepFlavour/data
-wget http://home.fnal.gov/~verzetti//DeepFlavour/training/DeepFlavourNoSL.json -O  RecoBTag/DeepFlavour/data/DeepFlavourNoSL.json
-wget http://mon.iihe.ac.be/~smoortga/DeepFlavour/CMSSW_implementation_DeepCMVA/Model_DeepCMVA.json -O RecoBTag/DeepFlavour/data/Model_DeepCMVA.json
-
-git clone -b egm_id_80X_v1 https://github.com/ikrav/RecoEgamma-ElectronIdentification.git data1 
-git clone -b egm_id_80X_v1 https://github.com/ikrav/RecoEgamma-PhotonIdentification.git data2
-git clone https://github.com/cms-data/RecoEgamma-ElectronIdentification data3
-
-rsync -avz data1/* RecoEgamma/ElectronIdentification/data/
-rsync -avz data2/* RecoEgamma/ElectronIdentification/data/
-rsync -avz data3/* RecoEgamma/PhotonIdentification/data/
-rm -rf data1 data2 data3
+#git-cms-addpkg RecoEgamma/ElectronIdentification
+#git-cms-addpkg EgammaAnalysis/ElectronTools
+#git-cms-addpkg RecoMET/METFilters
+#git-cms-addpkg RecoBTag/DeepFlavour
 
 git clone https://github.com/vallot/CATTools
 cd CATTools
-git checkout -b v8-0-7 v8-0-7
+git checkout -b cat90x cat90x
 git submodule init
 git submodule update
 cd ..
@@ -52,12 +21,12 @@ rm -f CATTools/CatAnalyzer/data/KinReco_input.root
 rm -f CATTools/CatAnalyzer/data/KoreaDesyKinRecoInput.root
 rm -f CATTools/CatAnalyzer/data/KoreaKinRecoInput_pseudo.root
 rm -f CATTools/CatAnalyzer/data/desyKinRecoInput.root
-rm -rf RecoEgamma/*Identification/data/Spring15
-rm -rf RecoEgamma/*Identification/data/PHYS14
+#rm -rf RecoEgamma/*Identification/data/Spring15
+#rm -rf RecoEgamma/*Identification/data/PHYS14
 
 scram b -j30
 
-catGetDatasetInfo
+catGetDatasetInfo v9-0-0
 
 ## Production only - do the unit test
 #cd CATTools/CatProducer


### PR DESCRIPTION
9XY migration, continued from #721 

- Migration to std::unique_ptr <- auto_ptr is deprecated from 9XY and does not compile
- Migration to use cms.Task <- necessary from 91X https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideAboutPythonConfigFile#Task_Objects
  - some modifications to pick up eventcontents + modules into task, etc
- New unit test input root file (from xrootd for this PR, can be changed if we have any sample in T3)
+ other minor changes