### PR TITLE
Add EE noise mitigation for MET

### DIFF
--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -16,7 +16,7 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
             LumiSections = LumiList('%s/src/CATTools/CatProducer/data/LumiMask/%s.txt'%(os.environ['CMSSW_BASE'], cat.lumiJSON)).getVLuminosityBlockRange())
 
         #process.load("CATTools.CatProducer.eventCleaning.badECALSlewRateMitigationFilter2016_cfi")
-    
+
 #    useJECfile = True
 #    jecFiles = cat.JetEnergyCorrection
 #    if runOnMC:
@@ -103,6 +103,20 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         #process = enableMETMuonRecoMitigation2016(process, runOnMC) ## MET input object is overridden in the modifier function
 
         process.catSkimEvent.electronIdNames = process.catElectrons.electronIDs
+
+    if useMiniAOD:
+      # Instructions for 9_4_X, X >=9 for 2017 data with EE noise mitigation
+      from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
+      runMetCorAndUncFromMiniAOD (
+              process,
+              isData = not runOnMC,
+              fixEE2017 = True,
+              postfix = "ModifiedMET"
+      )
+
+      process.p += process.fullPatMetSequenceModifiedMET
+      process.catMETs.src = cms.InputTag("slimmedMETsModifiedMET","","CAT")
 
 def addEgmID(process, runOnMC):
         #######################################################################

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@ cmsenv
 git-cms-init -q
 git checkout -b cat90x
 
+git cms-addpkg PhysicsTools/PatAlgos
 git cms-merge-topic cms-met:METFixEE2017_949
 #git-cms-addpkg RecoEgamma/ElectronIdentification
 #git-cms-addpkg EgammaAnalysis/ElectronTools

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,10 @@
-scram project -n cattools CMSSW_9_1_14_patch2
+scram project -n cattools CMSSW_9_4_9
 cd cattools/src
 cmsenv
 git-cms-init -q
 git checkout -b cat90x
 
+git cms-merge-topic cms-met:METFixEE2017_949
 #git-cms-addpkg RecoEgamma/ElectronIdentification
 #git-cms-addpkg EgammaAnalysis/ElectronTools
 #git-cms-addpkg RecoMET/METFilters


### PR DESCRIPTION
- Based on https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETUncertaintyPrescription#Instructions_for_9_4_X_X_9_for_2 
- Minimum release version required is CMSSW_9_4_9
 - Need to add `git cms-merge-topic cms-met:METFixEE2017_949` to the recipe
 - Must be used with the latest JEC (`Fall17_17Nov2017_V8`) which is already included in GT so it should be ok
 
Impact on MET (red is with mitigation, blue without) for MC:

<img width="997" alt="slimmemed_rediswithcorrection" src="https://user-images.githubusercontent.com/3646269/45266159-d9db1180-b456-11e8-9f92-fac526f764c1.png">

Impact on MET (red is with mitigation, blue without) for data:

<img width="890" alt="slimmedmet_rediswithcorrection_data" src="https://user-images.githubusercontent.com/3646269/45266203-83220780-b457-11e8-9198-5620817c3b1a.png">

NB:
 - an update of this recipe should be delivered soon by JETMET
 - this is a temporary fix, a proper modeling of the EE noise will be included in next re-reco

