### PR TITLE
Bugfix scale factor evaluator

### DIFF
--- a/CommonTools/src/ScaleFactorEvaluator.cc
+++ b/CommonTools/src/ScaleFactorEvaluator.cc
@@ -24,10 +24,17 @@ void ScaleFactorEvaluator::set(const std::vector<double>& xbins,
 
 double ScaleFactorEvaluator::operator()(const double x, const double y, const double shift) const
 {
+  // Filter out UF and OF
+  if ( x < (*xbins_.begin()) or x >= (*(xbins_.end()-1)) ) return 1;
+  if ( y < (*ybins_.begin()) or y >= (*(ybins_.end()-1)) ) return 1;
+
+  // Special note: std::lower_bound DOES NOT GIVE lower bound of the bin,
+  // it gives the first element which satiesfiles (x < VECTOR_ELEMENT)
+  // - as it is desigend to properly work on integers
   auto xbin = std::lower_bound(xbins_.begin(), xbins_.end(), x);
-  if ( xbin == xbins_.end() or xbin+1 == xbins_.end() ) return 1;
   auto ybin = std::lower_bound(ybins_.begin(), ybins_.end(), y);
-  if ( ybin == ybins_.end() or ybin+1 == ybins_.end() ) return 1;
+  if ( (*xbin) != x ) --xbin;
+  if ( (*ybin) != y ) --ybin;
 
   const int column = xbin-xbins_.begin();
   const int row = ybin-ybins_.begin();

--- a/CommonTools/src/ScaleFactorEvaluator.cc
+++ b/CommonTools/src/ScaleFactorEvaluator.cc
@@ -1,6 +1,6 @@
 #include "CATTools/CommonTools/interface/ScaleFactorEvaluator.h"
 #include <cassert>
-#include <algorithms>
+#include <algorithm>
 
 using namespace cat;
 

--- a/CommonTools/src/ScaleFactorEvaluator.cc
+++ b/CommonTools/src/ScaleFactorEvaluator.cc
@@ -1,5 +1,6 @@
 #include "CATTools/CommonTools/interface/ScaleFactorEvaluator.h"
 #include <cassert>
+#include <algorithms>
 
 using namespace cat;
 
@@ -28,13 +29,8 @@ double ScaleFactorEvaluator::operator()(const double x, const double y, const do
   if ( x < (*xbins_.begin()) or x >= (*(xbins_.end()-1)) ) return 1;
   if ( y < (*ybins_.begin()) or y >= (*(ybins_.end()-1)) ) return 1;
 
-  // Special note: std::lower_bound DOES NOT GIVE lower bound of the bin,
-  // it gives the first element which satiesfiles (x < VECTOR_ELEMENT)
-  // - as it is desigend to properly work on integers
-  auto xbin = std::lower_bound(xbins_.begin(), xbins_.end(), x);
-  auto ybin = std::lower_bound(ybins_.begin(), ybins_.end(), y);
-  if ( (*xbin) != x ) --xbin;
-  if ( (*ybin) != y ) --ybin;
+  auto xbin = std::upper_bound(xbins_.begin(), xbins_.end(), x)-1;
+  auto ybin = std::upper_bound(ybins_.begin(), ybins_.end(), y)-1;
 
   const int column = xbin-xbins_.begin();
   const int row = ybin-ybins_.begin();

--- a/CommonTools/src/ScaleFactorEvaluator.cc
+++ b/CommonTools/src/ScaleFactorEvaluator.cc
@@ -48,10 +48,12 @@ double ScaleFactorEvaluator::getScaleFactor(const cat::Particle& p, const int pi
   if ( aid == pid ) {
     const double x = p.pt(), y = p.eta();
     
-    auto xbin = std::lower_bound(xbins_.begin(), xbins_.end(), x);
-    if ( xbin == xbins_.end() or xbin+1 == xbins_.end() ) return 1;
-    auto ybin = std::lower_bound(ybins_.begin(), ybins_.end(), y);
-    if ( ybin == ybins_.end() or ybin+1 == ybins_.end() ) return 1;
+    // Filter out UF and OF
+    if ( x < (*xbins_.begin()) or x >= (*(xbins_.end()-1)) ) return 1;
+    if ( y < (*ybins_.begin()) or y >= (*(ybins_.end()-1)) ) return 1;
+
+    auto xbin = std::upper_bound(xbins_.begin(), xbins_.end(), x)-1;
+    auto ybin = std::upper_bound(ybins_.begin(), ybins_.end(), y)-1;
 
     const int column = xbin-xbins_.begin();
     const int row = ybin-ybins_.begin();

--- a/setup.sh
+++ b/setup.sh
@@ -11,12 +11,10 @@ git cms-merge-topic cms-met:METFixEE2017_949
 #git-cms-addpkg RecoMET/METFilters
 #git-cms-addpkg RecoBTag/DeepFlavour
 
-git clone https://github.com/vallot/CATTools
-cd CATTools
-git checkout -b cat90x cat90x
-git submodule init
-git submodule update
-cd ..
+git clone https://github.com/vallot/CATTools -b cat90x --recurse-submodules -j8
+cd CATTools/CommonTools/scripts
+git checkout master
+cd ../../..
 
 ## Production only - remove large files because of limitation in crab job file size
 rm -f CATTools/CatAnalyzer/data/KinReco_input.root


### PR DESCRIPTION
Bugfix for the ScaleFactorEvalulator.
Fixes bin shifting in some cases. 

We were using std::lower_bound to find histogram binning, but actually the name was given to return the "lower boundary of elements with the same value" - to return 4th element if "44" was asked to be found in a vector [0,1,2,44,44,44,555,678]. And the actual implementation is done to do the binary search with the comparison operator.

Simple and correct solution is to return the element BEFORE std::upper_bound().
