### PR TITLE
Parton Shower Weights and their information

### DIFF
--- a/CatProducer/plugins/GenWeightsProducer.cc
+++ b/CatProducer/plugins/GenWeightsProducer.cc
@@ -346,7 +346,7 @@ void GenWeightsProducer::beginRunProduce(edm::Run& run, const edm::EventSetup&)
     if ( not doVariations or variations.size() == 0 ) break;
 
     // Now we have all names and meanings of the variations. Put into the GenWeightInfo object
-    out_genWeightInfo->addWeightGroup("PSWeight", "gaussian", variations, keys);
+    out_genWeightInfo->addWeightGroup("PSWeight", "pick_one_set__Def_is_recommended", variations, keys);
 
   } while ( false );
 
@@ -428,7 +428,9 @@ void GenWeightsProducer::produce(edm::Event& event, const edm::EventSetup& event
           out_genWeights->addWeight(w);
         }
       }
-      for ( size_t i=0; i<genInfoHandle->weights().size(); ++i ) {
+      // NOTE: loop starts from 2, weight0 and 1 are central ME and replica
+      //       see https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopModGen
+      for ( size_t i=2; i<genInfoHandle->weights().size(); ++i ) {
         const double w0 = genInfoHandle->weights().at(i);
         const double w = w0*genRescale;
         out_genWeights->addWeight(w);


### PR DESCRIPTION
Parton shower weights are newly introduced in the most recent samples.
https://twiki.cern.ch/twiki/bin/viewauth/CMS/TopModGen#Event_Generation

> Pythia8 PS weights started to be produced on Fall17 campaign:
>
>    3 sets of PS weights implemented:
>        sqrt(2) and 1/sqrt(2) (reduced, aka Red),
>        2 and 0.5 (default, aka Def) -> this is the variation considered up to now in PS variated explicit >samples
>        4 and 0.25 (conservative, aka Con) 
>    They can be accessed through EDM branch:
>
>     GenEventInfoProduct_generator__SIM.obj.weights_ 
>
> First two weights (weightID= 0 and 1) correspond to central ME weight value and replica.
> The remaining 12 values (weightIDs = 2 to 13) correspond to the PS weights in the following order (ISR up, FSR up, ISR down, FSR down) x 3 sets, i.e.:
>
>        2 = isrRedHi isr:muRfac=0.707, 3 = fsrRedHi fsr:muRfac=0.707, 4 = isrRedLo isr:muRfac=1.414, 5 = fsrRedLo fsr:muRfac=1.414, 
>
>        6 = isrDefHi isr:muRfac=0.5, 7 = fsrDefHi fsr:muRfac=0.5,  8 = isrDefLo isr:muRfac=2.0,   9 = fsrDefLo fsr:muRfac=2.0, 
>
>        10 = isrConHi isr:muRfac=0.25, 11 = fsrConHi fsr:muRfac=0.25, 12 = isrConLo isr:muRfac=4.0, 13 = fsrConLo fsr:muRfac=4.0 
>

They are stored in the genEventInfo/weights as vector of float variables.
Their actual meanings are available in the configuration, which can be browsed usually with edmProvDump command.

In this PR, we retrieve provenance from the event, extract ParameterSet of the Pythia8 generator during the SIM step, parse pythia process parameter especially the uncertainty band list and put into the catGenWeights and related objects.

PSWeights are added into the catGenWeights, one have to find the corresponding index by retrieving the information from the catGenWeightInfo object or use the FlatGenWeightProducer.

![image](https://user-images.githubusercontent.com/4388926/46220080-14fca080-c384-11e8-809d-39e0921668d2.png)

The FlatGenWeightProducer is also modified, to produce PS weights in vector<float> format. 

NOTE: index in the genEventInfo->weight to be double checked