### PR TITLE
Fix genTop crash

### DIFF
--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -793,11 +793,11 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
     if( addbJetsBHad[i].pt() > 40 && std::abs(addbJetsBHad[i].eta()) < 2.5) NaddbJets40BHad_++;
   }
 
-  for( unsigned int i = 0 ; i < bJetsFromTop.size() ; i++){
+  for( unsigned int i = 0, n = std::min(bJetsFromTop_.size(), bJetsFromTop.size()) ; i < n ; i++){
     bJetsFromTop_[i] = bJetsFromTop[i];
   }
 
-  for( unsigned int i = 0 ; i < HbJets.size() ; i++){
+  for( unsigned int i = 0, n = std::min(HbJets_.size(), HbJets.size()) ; i < n ; i++){
     HbJets_[i] = HbJets[i];
   }
 


### PR DESCRIPTION
There was a report by @minerva1993 that some production jobs on MC samples were crashing.
This PR introduces safer loops to avoid segmentation faults.

"bJetsFromTop" is usually expected to be less than 2, but there are 3 (or possibly more) jets in some event(s). The original code is not safe from assigning values which are out of the range.

Following log messages print out pt of bJetsFromTop, where the number of this object is expected not to exceed 2. You can see 3rd jet appears with pT=14GeV.

```
%MSG
Begin processing the 1st record. Run 1, Event 6601227, LumiSection 4436 at 08-Oct-2018 13:12:37.617 KST
195.33
18.4032
Begin processing the 2nd record. Run 1, Event 6601226, LumiSection 4436 at 08-Oct-2018 13:13:21.263 KST
211.146
107.865
14.6316


A fatal system signal has occurred: segmentation violation
The following is the call stack containing the origin of the signal.


```