### PR TITLE
retrieve cutbasedID, correct AEff, modify noiso ID

### DIFF
--- a/CatProducer/plugins/CATElectronProducer.cc
+++ b/CatProducer/plugins/CATElectronProducer.cc
@@ -290,9 +290,9 @@ void cat::CATElectronProducer::produce(edm::Event & iEvent, const edm::EventSetu
     }
 
     aElectron.setIsPF( aPatElectron.isPF() );
-    aElectron.setIsTight( aElectron.electronID("mvaEleID-Fall17-iso-V2-wp80") );
-    aElectron.setIsMedium( aElectron.electronID("mvaEleID-Fall17-iso-V2-wp90") );
-    aElectron.setIsLoose( aElectron.electronID("mvaEleID-Fall17-iso-V2-wpLoose") );
+    aElectron.setIsTight( aElectron.electronID("cutBasedElectronID-Fall17-94X-V2-tight") );
+    aElectron.setIsMedium( aElectron.electronID("cutBasedElectronID-Fall17-94X-V2-medium") );
+    aElectron.setIsLoose( aElectron.electronID("cutBasedElectronID-Fall17-94X-V2-loose") );
 
     reco::GsfTrackRef theTrack = aPatElectron.gsfTrack();
     aElectron.setDxy( theTrack->dxy(pv.position()) );
@@ -433,23 +433,15 @@ int cat::CATElectronProducer::getSNUID(float full5x5_sigmaIetaIeta, float deltaE
 float
 cat::CATElectronProducer::getEffArea( float dR, float scEta)
 {
-  // ElectronEffectiveArea::ElectronEffectiveAreaTarget electronEATarget;
-  // if ( runOnMC_ ) electronEATarget = ElectronEffectiveArea::kEleEAFall11MC;
-  // else electronEATarget = ElectronEffectiveArea::kEleEAData2012;
-  // if( dR < 0.35)
-  //   return ElectronEffectiveArea::GetElectronEffectiveArea( ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, scEta, electronEATarget);
-  // else
-  //   return ElectronEffectiveArea::GetElectronEffectiveArea( ElectronEffectiveArea::kEleGammaAndNeutralHadronIso04, scEta, electronEATarget);
-
-  // new effArea  https://github.com/ikrav/cmssw/blob/egm_id_80X_v1/RecoEgamma/ElectronIdentification/data/Summer16/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_80X.txt
+  // https://github.com/guitargeek/cmssw/blob/EgammaID_949/RecoEgamma/ElectronIdentification/data/Fall17/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_92X.txt
   float absEta = std::abs(scEta);
-  if ( 0.0000 >= absEta && absEta < 1.0000 ) return 0.1703;
-  if ( 1.0000 >= absEta && absEta < 1.4790 ) return 0.1715;
-  if ( 1.4790 >= absEta && absEta < 2.0000 ) return 0.1213;
-  if ( 2.0000 >= absEta && absEta < 2.2000 ) return 0.1230;
-  if ( 2.2000 >= absEta && absEta < 2.3000 ) return 0.1635;
-  if ( 2.3000 >= absEta && absEta < 2.4000 ) return 0.1937;
-  if ( 2.4000 >= absEta && absEta < 5.0000 ) return 0.2393;
+  if ( 0.0000 >= absEta && absEta < 1.0000 ) return 0.1566;
+  if ( 1.0000 >= absEta && absEta < 1.4790 ) return 0.1626;
+  if ( 1.4790 >= absEta && absEta < 2.0000 ) return 0.1073;
+  if ( 2.0000 >= absEta && absEta < 2.2000 ) return 0.0854;
+  if ( 2.2000 >= absEta && absEta < 2.3000 ) return 0.1051;
+  if ( 2.3000 >= absEta && absEta < 2.4000 ) return 0.1204;
+  if ( 2.4000 >= absEta && absEta < 5.0000 ) return 0.1524;
   return 0;
 }
 

--- a/CatProducer/python/catDefinitions_cfi.py
+++ b/CatProducer/python/catDefinitions_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 bunchCrossing  = 25
-globalTag_mc   = '94X_mc2017_realistic_v14'
-globalTag_rd   = '94X_dataRun2_v6'
+globalTag_mc   = '94X_mc2017_realistic_v17'
+globalTag_rd   = '94X_dataRun2_v11'
 lumiJSON       = 'Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON'
 pileupMCmap    = '2017_25ns_WinterMC'
 

--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -145,6 +145,5 @@ def addEgmID(process, runOnMC):
         #process = enablePhotonVID(process)
 
         ## Electron ID without isolation cuts
-        #from CATTools.CatProducer.patTools.egmNoIsoID_cff import enableElectronNoIsoID
-        #process = enableElectronNoIsoID(process)
-
+        from CATTools.CatProducer.patTools.egmNoIsoID_cff import enableElectronNoIsoID
+        process = enableElectronNoIsoID(process)

--- a/CatProducer/python/patTools/egmNoIsoID_cff.py
+++ b/CatProducer/python/patTools/egmNoIsoID_cff.py
@@ -14,7 +14,8 @@ def enableElectronNoIsoID(process):
 
         for cut in idSet.idDefinition.cutFlow:
             newCut = cut.clone()
-            if newCut.cutName.value().endswith('IsoCut'): newCut.isIgnored = True
+            #configureVIDCutBasedEleID_V5 for 2017 90x V2 iD
+            if newCut.cutName.value().endswith('IsoScaledCut'): newCut.isIgnored = True
             newCutFlow.append(newCut)
 
         newIdSet = cms.PSet(

--- a/CatProducer/python/patTools/egmVersionedID_cff.py
+++ b/CatProducer/python/patTools/egmVersionedID_cff.py
@@ -8,6 +8,7 @@ def enableElectronVID(process):
     electron_ids = [
         'mvaElectronID_Fall17_noIso_V2_cff',
         'mvaElectronID_Fall17_iso_V2_cff',
+        'cutBasedElectronID_Fall17_94X_V2_cff',
     ]
     for idmod in electron_ids:
         idmod = "RecoEgamma.ElectronIdentification.Identification."+idmod
@@ -21,6 +22,10 @@ def enableElectronVID(process):
         "egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wp80",
         "egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wpLoose",
         "egmGsfElectronIDs:mvaEleID-Fall17-iso-V2-wpHZZ",
+        "egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-veto",
+        "egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-loose",
+        "egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-medium",
+        "egmGsfElectronIDs:cutBasedElectronID-Fall17-94X-V2-tight",
     ]
     process.catElectrons.electronIDSources = cms.PSet()
     for idName in electron_idNames:


### PR DESCRIPTION
Here's some codes to retrieve cunBasedElectronID. (Because the electron trigger SF made by ttH group used this ID) 

NoIso id code is modified, following
https://github.com/guitargeek/cmssw/blob/EgammaID_949/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Fall17_94X_V2_cff.py#L7-L9

and

https://github.com/guitargeek/cmssw/blob/EgammaID_949/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_tools.py#L746
