### PR TITLE
Fix compile error, typo in TtbarBbbar analyzer

### DIFF
--- a/CatAnalyzer/BuildFile.xml
+++ b/CatAnalyzer/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="CATTools/DataFormats"/>
 <use name="TopQuarkAnalysis/TopKinFitter"/>
+<use name="rootminuit" />
 <use name="rootminuit2" />
 <export>
   <lib   name="1"/>

--- a/CatAnalyzer/plugins/TtbarBbbarDiLeptonAnalyzer.cc
+++ b/CatAnalyzer/plugins/TtbarBbbarDiLeptonAnalyzer.cc
@@ -792,7 +792,7 @@ void TtbarBbbarDiLeptonAnalyzer::analyze(const edm::Event& iEvent, const edm::Ev
     int is_partonInPhaseLep=0;
     for ( auto  aParticle = genParticles->begin(),end = genParticles->end(); aParticle != end; ++aParticle ) {
       const reco::GenParticle& p = *aParticle;
-      if ( !(abs(p.pdgId()) > 21 && abs(p.pdgId()) << 26)  ) continue;
+      if ( !(abs(p.pdgId()) > 21 && abs(p.pdgId()) < 26)  ) continue;
       if ( !cat::isLast(p) ) continue;
       unsigned int nDaughters = p.numberOfDaughters();
       for ( unsigned iDaughter=0; iDaughter<nDaughters; ++iDaughter ) {


### PR DESCRIPTION
Fixed compilation faiure and warning

- Linking error due to missing library
- A serious typo was discovered thanks to the advanced compiler 