### PR TITLE
Change dRW=0.4 to remove not ttjj and NaddbJet > 1

### DIFF
--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -525,35 +525,35 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
       double dR = reco::deltaR(gJet, leptons_[i]);
       if( dR < minDRlepton ) minDRlepton = dR;
     }
-    if( minDRlepton < 0.5) continue;
+    if( minDRlepton < 0.4 ) continue;
 
     double minDR = 999;
     for(unsigned int i=0 ; i < bquarks.size() ; i++){
       double dR = reco::deltaR(gJet, bquarks[i]);
       if( dR < minDR ) minDR = dR;
     }
-    if( minDR < 0.5 ) bJets.push_back(gJet.p4());
+    if( minDR < 0.4 ) bJets.push_back(gJet.p4());
 
     double minDR2b = 999;
     for(unsigned int i=0 ; i < bquarksfromnotop.size() ; i++){
       double dR = reco::deltaR(gJet, bquarksfromnotop[i]);
       if( dR < minDR2b ) minDR2b = dR;
     }
-    if( minDR2b < 0.5 ) addbJets.push_back(gJet.p4());
+    if( minDR2b < 0.4 ) addbJets.push_back(gJet.p4());
 
     double minDR2c = 999;
     for(unsigned int i=0 ; i < cquarks.size() ; i++){
       double dR = reco::deltaR(gJet, cquarks[i]);
       if( dR < minDR2c ) minDR2c = dR;
     }
-    if( minDR2c < 0.5 ) cJets.push_back(gJet.p4());
+    if( minDR2c < 0.4 ) cJets.push_back(gJet.p4());
 
     double minDR2addc = 999;
     for(unsigned int i=0 ; i < addcquarks.size() ; i++){
       double dR = reco::deltaR(gJet, addcquarks[i]);
       if( dR < minDR2addc ) minDR2addc = dR;
     }
-    if( minDR2addc < 0.5 ) addcJets.push_back(gJet.p4());
+    if( minDR2addc < 0.4 ) addcJets.push_back(gJet.p4());
 
     NJets_++;
     if( gJet.pt() > 40 && std::abs(gJet.eta()) < 2.5 ) NJets40_++;
@@ -576,7 +576,7 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
     //cout << "bJetFromTopIds = " <<  bJetFromTopIds.count(idx) << " bJetFromTopIds = " 
     //<<  bJetFromWIds.count(idx) << " cJetFromWIds = " << cJetFromWIds.count(idx) << endl;
 
-    if(bJetFromTopIds.count(idx) < 1 && bJetFromWIds.count(idx) < 1 && cJetFromWIds.count(idx) < 1) {
+    if( bJetFromTopIds.count(idx) < 1 && bJetFromWIds.count(idx) < 1 && cJetFromWIds.count(idx) < 1 ) {
       double minDRWquarks = 999;
       int FlavCand = 0;
       for(unsigned int i=0 ; i < quarksfromW_.size() ; i++){
@@ -590,7 +590,7 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
       if( minDRWquarks > 0.4 ){
         addJets.push_back( gJet.p4() );
       }
-      else if ( minDRWquarks < 0.5) { // Only for Light Quarks
+      else if ( minDRWquarks <= 0.4 ) { // Only for Light Quarks
 	JetsFromW.push_back( gJet.p4() );
 	JetsFlavourFromW.push_back( FlavCand );
 	//debug
@@ -598,18 +598,23 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
       }
     }
 
-    if(bJetIds.count(idx) > 0){
+    if( bJetIds.count(idx) > 0 ){
       bJetsBHad.push_back( gJet.p4() );
       if( bJetFromTopIds.count(idx) > 0) bJetsFromTop.push_back( gJet.p4() ); 
-      if( bJetAdditionalIds.count(idx) > 0 ) addbJetsBHad.push_back( gJet.p4() ); 
+      if( bJetAdditionalIds.count(idx) > 0 ){
+	  addbJetsBHad.push_back( gJet.p4() ); 
+	      
+	  auto itr = std::find(addJets.begin(), addJets.end(), gJet.p4());
+	  if( itr == addJets.end() ) addJets.push_back( gJet.p4() );
+      }
       if( bJetFromWIds.count(idx) > 0 ){
 	JetsFromW.push_back( gJet.p4() );
 	JetsFlavourFromW.push_back( 5 );
       }    
-      if( bJetFromHiggsIds.count(idx) > 0) HbJets.push_back( gJet.p4() );
+      if( bJetFromHiggsIds.count(idx) > 0 ) HbJets.push_back( gJet.p4() );
     }
     
-    if(cJetIds.count(idx) > 0){
+    if( cJetIds.count(idx) > 0 ){
       cJetsCHad.push_back( gJet.p4() );
       if( cJetAdditionalIds.count(idx) > 0 ) addcJetsCHad.push_back( gJet.p4() ); 
       if( cJetFromWIds.count(idx) > 0 ){

--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -587,7 +587,7 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
 	  FlavCand = qflavourfromW_[i];
 	}
       }
-      if( minDRWquarks > 0.5 ){
+      if( minDRWquarks > 0.4 ){
         addJets.push_back( gJet.p4() );
       }
       else if ( minDRWquarks < 0.5) { // Only for Light Quarks


### PR DESCRIPTION
To reduce difference between the number of events from eventinfo and from gentree, changing the dRWquarks from 0.5 to 0.4.