### PR TITLE
GenTop Modification for cat 90x

### DIFF
--- a/CatAnalyzer/plugins/ttbbLepJetsAnalyzer.cc
+++ b/CatAnalyzer/plugins/ttbbLepJetsAnalyzer.cc
@@ -699,7 +699,7 @@ void ttbbLepJetsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
   //---------------------------------------------------------------------------
   // Weights for Syst. Scale and PDF: ttbar
   //---------------------------------------------------------------------------
-  if(TTbarMC_ == 1 ) {
+  if(TTbarMC_ >= 1 ) {
     // Scale weights
     edm::Handle<std::vector<float>> scaleUpWeightsHandle, scaleDownWeightsHandle;
     iEvent.getByToken(scaleUpWeightToken_,   scaleUpWeightsHandle);

--- a/DataFormats/interface/GenTop.h
+++ b/DataFormats/interface/GenTop.h
@@ -108,6 +108,10 @@ namespace cat {
     const math::XYZTLorentzVector addJets2() const { return addJets_[1]; }
 
     const std::vector<math::XYZTLorentzVector> bJets() const { return bJets_; }
+    const std::vector<math::XYZTLorentzVector> addbJets(int i = 0) const {
+      if( i == 0 ) return addbJetsHad_;
+      else return addbJets_;
+    }
 
     //void building( const std::vector<reco::GenJet>* genJets, const std::vector<reco::GenParticle>* genParticles );
     void building( Handle<reco::GenJetCollection> genJets, Handle<reco::GenParticleCollection> genParticles, Handle<std::vector<int> > genBHadFlavour, Handle<std::vector<int> > genBHadJetIndex, Handle<std::vector<int> > genCHadFlavour, Handle<std::vector<int> > genCHadJetIndex  );

--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -796,6 +796,9 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
     if( i < 2 ){
       addbJetsHad_[i] = addbJetsBHad[i];
     }
+    else{
+      addbJetsHad_.push_back(addbJetsBHad[i]);
+    }
     NaddbJetsBHad_++;
     if( addbJetsBHad[i].pt() > 20 && std::abs(addbJetsBHad[i].eta()) < 2.5) NaddbJets20BHad_++;
     if( addbJetsBHad[i].pt() > 40 && std::abs(addbJetsBHad[i].eta()) < 2.5) NaddbJets40BHad_++;


### PR DESCRIPTION
1.GenTop: All additional b jet candidates are saved in vector and you can access them by addbJets().
2.ttbbLepjetAnalyzer: Scale weights are saved for all ttbar samples.