### PR TITLE
add deepFlavour in 2017

### DIFF
--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -58,8 +58,7 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
            jetSource = cms.InputTag('slimmedJets'),
            pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
            svSource = cms.InputTag('slimmedSecondaryVertices'),
-           labelName = 'UpdatedJEC',
-           jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None'),
+           jetCorrections = ('AK4PFchs', cms.vstring([]), 'None'),
            btagDiscriminators = [
               'pfDeepFlavourJetTags:probb',
               'pfDeepFlavourJetTags:probbb',
@@ -68,11 +67,22 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
               'pfDeepFlavourJetTags:probuds',
               'pfDeepFlavourJetTags:probg'
               ],
-            postfix='NewDFTraining'
+           postfix='NewDFTraining'
         )
-        process.p += process.patJetCorrFactorsUpdatedJECNewDFTraining
-        process.p += process.updatedPatJetsUpdatedJECNewDFTraining
-        process.catJets.src = cms.InputTag("updatedPatJetsUpdatedJECNewDFTraining","","CAT")
+        process.p += process.patJetCorrFactorsNewDFTraining
+        process.p += process.updatedPatJetsNewDFTraining
+
+        updateJetCollection(
+           process,
+           jetSource = cms.InputTag('slimmedJets'),
+           pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+           svSource = cms.InputTag('slimmedSecondaryVertices'),
+           labelName = 'UpdatedJEC',
+           jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None'),
+        )
+        process.p += process.patJetCorrFactorsUpdatedJEC
+        process.p += process.updatedPatJetsUpdatedJEC
+        process.catJets.src = cms.InputTag("updatedPatJetsUpdatedJEC","","CAT")
 
 #    if useMiniAOD: ## corrections when using miniAOD #This is stored in miniAOD as flag, in 2017
 #        from CATTools.CatProducer.patTools.metFilters_cff import enableAdditionalMETFilters

--- a/CatProducer/python/catTools_cff.py
+++ b/CatProducer/python/catTools_cff.py
@@ -56,12 +56,23 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
         updateJetCollection(
            process,
            jetSource = cms.InputTag('slimmedJets'),
+           pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+           svSource = cms.InputTag('slimmedSecondaryVertices'),
            labelName = 'UpdatedJEC',
-           jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None')
+           jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute', 'L2L3Residual']), 'None'),
+           btagDiscriminators = [
+              'pfDeepFlavourJetTags:probb',
+              'pfDeepFlavourJetTags:probbb',
+              'pfDeepFlavourJetTags:problepb',
+              'pfDeepFlavourJetTags:probc',
+              'pfDeepFlavourJetTags:probuds',
+              'pfDeepFlavourJetTags:probg'
+              ],
+            postfix='NewDFTraining'
         )
-        process.p += process.patJetCorrFactorsUpdatedJEC
-        process.p += process.updatedPatJetsUpdatedJEC
-        process.catJets.src = cms.InputTag("updatedPatJetsUpdatedJEC","","CAT")
+        process.p += process.patJetCorrFactorsUpdatedJECNewDFTraining
+        process.p += process.updatedPatJetsUpdatedJECNewDFTraining
+        process.catJets.src = cms.InputTag("updatedPatJetsUpdatedJECNewDFTraining","","CAT")
 
 #    if useMiniAOD: ## corrections when using miniAOD #This is stored in miniAOD as flag, in 2017
 #        from CATTools.CatProducer.patTools.metFilters_cff import enableAdditionalMETFilters
@@ -100,8 +111,8 @@ def catTool(process, runOnMC=True, useMiniAOD=True):
 #        process = enableQGLikelihood(process, qgDatabaseVersion="v2b", runOnMC=runOnMC, useMiniAOD=useMiniAOD)
 
         ## DeepFlavour
-        from CATTools.CatProducer.patTools.jetDeepFlavour_cff import enableDeepFlavour
-        process = enableDeepFlavour(process)
+        #from CATTools.CatProducer.patTools.jetDeepFlavour_cff import enableDeepFlavour
+        #process = enableDeepFlavour(process)
 
         ## #######################################################################
         ## # MET corrections from https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription

--- a/CatProducer/python/producers/jetProducer_cfi.py
+++ b/CatProducer/python/producers/jetProducer_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 catJets = cms.EDProducer('CATJetProducer',
     src = cms.InputTag('slimmedJets'),
     rho = cms.InputTag('fixedGridRhoFastjetAll'),
-    btagNames = cms.vstring('pfCombinedInclusiveSecondaryVertexV2BJetTags',"pfDeepCSVDiscriminatorsJetTags:BvsAll","pfDeepCSVJetTags:probb","pfDeepCSVJetTags:probbb","pfDeepCSVJetTags:probc","pfDeepCSVJetTags:probcc", "pfDeepCSVJetTags:probudsg", "pfDeepCSVDiscriminatorsJetTags:CvsB","pfDeepCSVDiscriminatorsJetTags:CvsL","pfCombinedCvsLJetTags","pfCombinedCvsBJetTags"),
+    btagNames = cms.vstring('pfCombinedInclusiveSecondaryVertexV2BJetTags',"pfDeepCSVDiscriminatorsJetTags:BvsAll","pfDeepCSVJetTags:probb","pfDeepCSVJetTags:probbb","pfDeepCSVJetTags:probc","pfDeepCSVJetTags:probcc", "pfDeepCSVJetTags:probudsg", "pfDeepCSVDiscriminatorsJetTags:CvsB","pfDeepCSVDiscriminatorsJetTags:CvsL","pfCombinedCvsLJetTags","pfCombinedCvsBJetTags","pfDeepFlavourJetTags:probb","pfDeepFlavourJetTags:probbb","pfDeepFlavourJetTags:problepb","pfDeepFlavourJetTags:probc","pfDeepFlavourJetTags:probuds","pfDeepFlavourJetTags:probg"),
     payloadName = cms.string('AK4PFchs'),
     jetResFile   = cms.string("CATTools/CatProducer/data/JER/Fall17_V3_MC_PtResolution_AK4PFchs.txt"),
     jetResSFFile = cms.string("CATTools/CatProducer/data/JER/Fall17_V3_MC_SF_AK4PFchs.txt"),


### PR DESCRIPTION
Some message during test run:

**************************************************************
b tagging needs to be run on uncorrected jets. Hence, the JECs
will first be undone for 'updatedPatJetsUpdatedJECNewDFTraining' and then applied to
'updatedPatJetsTransientCorrectedUpdatedJECNewDFTraining'.
**************************************************************

Begin processing the 1st record. Run 1, Event 6681309, LumiSection 8016 at 15-Jul-2020 12:43:49.029 KST
%MSG-w L3Absolute not found:   PATJetUpdater:updatedPatJetsUpdatedJECNewDFTraining 15-Jul-2020 12:43:49 KST  Run: 1 Event: 6681309
L2L3Residual and L3Absolute are not part of the jetCorrFactors
of module patJetCorrFactorsUpdatedJECNewDFTraining. Jets will remain uncorrected.

Seems that there's some issue, work in progress.