### PR TITLE
GenTop modification for cat81x

### DIFF
--- a/CatProducer/python/Tools/tools.py
+++ b/CatProducer/python/Tools/tools.py
@@ -68,6 +68,7 @@ def genHFTool(process, useMiniAOD = True):
     )
     process.GenTtbarCategoriesEta2p5 = process.categorizeGenTtbar.clone(
        genJets = cms.InputTag(genJetCollection),
+       genJetPtMin = cms.double(20.),
        genJetAbsEtaMax = cms.double(2.5)
     )
 

--- a/CatProducer/python/Tools/tools.py
+++ b/CatProducer/python/Tools/tools.py
@@ -66,6 +66,10 @@ def genHFTool(process, useMiniAOD = True):
        genJets = cms.InputTag(genJetCollection),
        genJetPtMin = cms.double(40.)
     )
+    process.GenTtbarCategoriesEta2p5 = process.categorizeGenTtbar.clone(
+       genJets = cms.InputTag(genJetCollection),
+       genJetAbsEtaMax = cms.double(2.5)
+    )
 
     process.catGenTops.genJetLabel = genJetCollection
     process.catGenTops.mcParticleLabel = genParticleCollection

--- a/CatProducer/python/catCandidates_cff.py
+++ b/CatProducer/python/catCandidates_cff.py
@@ -52,7 +52,7 @@ def addCatGenTopObjects(process):
         process.matchGenBHadron, process.matchGenCHadron, 
         process.catGenTops, process.GenTtbarCategories, process.GenTtbarCategories30,
         process.GenTtbarCategories40, process.GenTtbarCategoriesEta2p5,
-	process.genJetHadronFlavour
+        process.genJetHadronFlavour
     )
     return process
 

--- a/CatProducer/python/catCandidates_cff.py
+++ b/CatProducer/python/catCandidates_cff.py
@@ -50,7 +50,7 @@ def addCatGenTopObjects(process):
     process.catObjectTask.add(
         process.selectedHadronsAndPartons, process.genJetFlavourInfos,
         process.matchGenBHadron, process.matchGenCHadron, 
-        process.catGenTops, process.GenTtbarCategories, process.GenTtbarCategories30,
+        process.catGenTops, process.GenTtbarCategories, process.GenTtbarCategories30, process.GenTtbarCategoriesEta2p5,
         process.GenTtbarCategories40, process.genJetHadronFlavour
     )
     return process

--- a/CatProducer/python/catCandidates_cff.py
+++ b/CatProducer/python/catCandidates_cff.py
@@ -50,8 +50,9 @@ def addCatGenTopObjects(process):
     process.catObjectTask.add(
         process.selectedHadronsAndPartons, process.genJetFlavourInfos,
         process.matchGenBHadron, process.matchGenCHadron, 
-        process.catGenTops, process.GenTtbarCategories, process.GenTtbarCategories30, process.GenTtbarCategoriesEta2p5,
-        process.GenTtbarCategories40, process.genJetHadronFlavour
+        process.catGenTops, process.GenTtbarCategories, process.GenTtbarCategories30,
+        process.GenTtbarCategories40, process.GenTtbarCategoriesEta2p5,
+	process.genJetHadronFlavour
     )
     return process
 

--- a/DataFormats/interface/GenTop.h
+++ b/DataFormats/interface/GenTop.h
@@ -108,6 +108,10 @@ namespace cat {
     const math::XYZTLorentzVector addJets2() const { return addJets_[1]; }
 
     const std::vector<math::XYZTLorentzVector> bJets() const { return bJets_; }
+    const std::vector<math::XYZTLorentzVector> addbJets(int i = 0) const {
+      if( i == 0 ) return addbJetsHad_;
+      else return addbJets_;
+    }
 
     //void building( const std::vector<reco::GenJet>* genJets, const std::vector<reco::GenParticle>* genParticles );
     void building( Handle<reco::GenJetCollection> genJets, Handle<reco::GenParticleCollection> genParticles, Handle<std::vector<int> > genBHadFlavour, Handle<std::vector<int> > genBHadJetIndex, Handle<std::vector<int> > genCHadFlavour, Handle<std::vector<int> > genCHadJetIndex  );

--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -797,7 +797,7 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
       addbJetsHad_[i] = addbJetsBHad[i];
     }
     else{
-      adbJetsHad_.push_back(addbJetsBHad[i]);
+      addbJetsHad_.push_back(addbJetsBHad[i]);
     }
     NaddbJetsBHad_++;
     if( addbJetsBHad[i].pt() > 20 && std::abs(addbJetsBHad[i].eta()) < 2.5) NaddbJets20BHad_++;

--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -634,7 +634,7 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
       if( minDRWquarks > 0.4 ){
         addJets.push_back( gJet.p4() );
       }
-      else if ( minDRWquarks <= 0.4 ) { // Only for Light Quarks
+      else if ( minDRWquarks <= 0.4 && bJetAdditionalIds.count(idx) < 1 && cJetAdditionalIds.count(idx) < 1 ) { // Only for Light Quarks
 	JetsFromW.push_back( gJet.p4() );
 	JetsFlavourFromW.push_back( FlavCand );
 	//debug
@@ -660,7 +660,12 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
     
     if( cJetIds.count(idx) > 0 ){
       cJetsCHad.push_back( gJet.p4() );
-      if( cJetAdditionalIds.count(idx) > 0 ) addcJetsCHad.push_back( gJet.p4() ); 
+      if( cJetAdditionalIds.count(idx) > 0 ){
+        addcJetsCHad.push_back( gJet.p4() ); 
+
+	auto itr = std::find(addJets.begin(), addJets.end(), gJet.p4());
+	if( itr == addJets.end() ) addJets.push_back( gJet.p4() );
+      }
       if( cJetFromWIds.count(idx) > 0 ){
 	JetsFromW.push_back( gJet.p4() );
 	JetsFlavourFromW.push_back( 4 );

--- a/DataFormats/src/GenTop.cc
+++ b/DataFormats/src/GenTop.cc
@@ -796,6 +796,9 @@ void GenTop::building(Handle<reco::GenJetCollection> genJets, Handle<reco::GenPa
     if( i < 2 ){
       addbJetsHad_[i] = addbJetsBHad[i];
     }
+    else{
+      adbJetsHad_.push_back(addbJetsBHad[i]);
+    }
     NaddbJetsBHad_++;
     if( addbJetsBHad[i].pt() > 20 && std::abs(addbJetsBHad[i].eta()) < 2.5) NaddbJets20BHad_++;
     if( addbJetsBHad[i].pt() > 40 && std::abs(addbJetsBHad[i].eta()) < 2.5) NaddbJets40BHad_++;


### PR DESCRIPTION
1. Additional c jets are included in additional jet vectors. To avoid duplication between JetFromW and AddJets, the bJetAdditionalIds < 1 and cJetAdditionalIds < 1are required to fill JetFromW.
2. To use GenTtbarCategorization in cms-sw with eta cut 2.5, GenTtbarCategoriesEta2p5 is declared.
If this pull request is no problem, I will make the pull request for cat90x and cat10x