### PR TITLE
Modif pdfweights and Muon Iso

### DIFF
--- a/CatAnalyzer/plugins/ttbbLepJetsAnalyzer.cc
+++ b/CatAnalyzer/plugins/ttbbLepJetsAnalyzer.cc
@@ -694,8 +694,10 @@ void ttbbLepJetsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
 
     std::vector<float> tmp_PDFWeight;
     for( auto& w : *PDFWeightsHandle ) tmp_PDFWeight.push_back(w);
-    // 9~112: NNPDF31_nnlo_hessian_pdfas
-    for( unsigned int i = 9; i < 112; ++i) b_PDFWeight->push_back(tmp_PDFWeight.at(i));
+    // CP5 - genWeights[10]~[111],[116],[117]: NNPDF31_nnlo_hessian_pdfas(306001~306102), as_0117(323300), as_0119(323500)
+    for( unsigned int i = 1; i < 103; ++i) b_PDFWeight->push_back(tmp_PDFWeight.at(i));
+    b_PDFWeight->push_back(tmp_PDFWeight.at(107));
+    b_PDFWeight->push_back(tmp_PDFWeight.at(108));
     for( unsigned int i = 0; i < b_PDFWeight->size(); ++i) PDFWeights->Fill(i, b_PDFWeight->at(i));
 
     // PS weight
@@ -1251,7 +1253,7 @@ bool ttbbLepJetsAnalyzer::IsSelectMuon(const cat::Muon & i_muon_candidate)
   bool GoodMuon=true;
 
   // Tight selection already defined into CAT::Muon
-  GoodMuon &= (i_muon_candidate.passed(reco::Muon::CutBasedIdTight|reco::Muon::PFIsoTight));
+  GoodMuon &= (i_muon_candidate.passed(reco::Muon::CutBasedIdTight));
 
   GoodMuon &= (i_muon_candidate.isPFMuon());           // PF
   GoodMuon &= (i_muon_candidate.pt()> 30);             // pT
@@ -1263,7 +1265,7 @@ bool ttbbLepJetsAnalyzer::IsSelectMuon(const cat::Muon & i_muon_candidate)
   // relIso( R ) already includes PU subtraction
   // float relIso = ( chIso + std::max(0.0, nhIso + phIso - 0.5*PUIso) )/ ecalpt;
 
-  if ( !doLooseLepton_ ) GoodMuon &=( i_muon_candidate.relIso( 0.4 ) < 0.15 );
+  if ( !doLooseLepton_ ) GoodMuon &=( i_muon_candidate.passed(reco::Muon::PFIsoTight) );
 
   //----------------------------------------------------------------------------------------------------
   //----------------------------------------------------------------------------------------------------

--- a/CatAnalyzer/prod/job_ttbb.sh
+++ b/CatAnalyzer/prod/job_ttbb.sh
@@ -9,7 +9,7 @@ create-batch --jobName DataSingleEGB --fileList $dataset_loc/dataset_EGamma_Run2
 create-batch --jobName DataSingleEGC --fileList $dataset_loc/dataset_EGamma_Run2018C.txt --cfg $cfg --transferDest $save_loc/DataSingleEGC --maxFiles 50 --args 'UserJSON=true runOnTTbarMC=0 TTbarCatMC=0'
 create-batch --jobName DataSingleEGD --fileList $dataset_loc/dataset_EGamma_Run2018D.txt --cfg $cfg --transferDest $save_loc/DataSingleEGD --maxFiles 50 --args 'UserJSON=true runOnTTbarMC=0 TTbarCatMC=0'
 ### Mu
-create-batch --jobName DataSingleMuA --fileList $dataset_loc/dataset_SingleMuon_Run2018A.txt --cfg $cfg --transferDest $save_loc/DataSingleMuB --maxFiles 50 --args 'UserJSON=true runOnTTbarMC=0 TTbarCatMC=0'
+create-batch --jobName DataSingleMuA --fileList $dataset_loc/dataset_SingleMuon_Run2018A.txt --cfg $cfg --transferDest $save_loc/DataSingleMuA --maxFiles 50 --args 'UserJSON=true runOnTTbarMC=0 TTbarCatMC=0'
 create-batch --jobName DataSingleMuB --fileList $dataset_loc/dataset_SingleMuon_Run2018B.txt --cfg $cfg --transferDest $save_loc/DataSingleMuB --maxFiles 50 --args 'UserJSON=true runOnTTbarMC=0 TTbarCatMC=0'
 create-batch --jobName DataSingleMuC --fileList $dataset_loc/dataset_SingleMuon_Run2018C.txt --cfg $cfg --transferDest $save_loc/DataSingleMuC --maxFiles 50 --args 'UserJSON=true runOnTTbarMC=0 TTbarCatMC=0'
 create-batch --jobName DataSingleMuD --fileList $dataset_loc/dataset_SingleMuon_Run2018D.txt --cfg $cfg --transferDest $save_loc/DataSingleMuD --maxFiles 50 --args 'UserJSON=true runOnTTbarMC=0 TTbarCatMC=0'
@@ -81,7 +81,7 @@ create-batch --jobName QCD_Pt-15to20_EMEnriched --fileList $dataset_loc/dataset_
 
 # Systematics
 ### hdamp Up
-create-batch --jobName TTLJ_PowhegPythia_SYS_hdampUp_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_hdampUP.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythiai_SYS_hdampUp_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
+create-batch --jobName TTLJ_PowhegPythia_SYS_hdampUp_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_hdampUP.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampUp_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
 create-batch --jobName TTLJ_PowhegPythia_SYS_hdampUp_ttbj --fileList $dataset_loc/dataset_TTLJ_powheg_hdampUP.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampUp_ttbj --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=2'
 create-batch --jobName TTLJ_PowhegPythia_SYS_hdampUp_ttcc --fileList $dataset_loc/dataset_TTLJ_powheg_hdampUP.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampUp_ttcc --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=3'
 create-batch --jobName TTLJ_PowhegPythia_SYS_hdampUp_ttLF --fileList $dataset_loc/dataset_TTLJ_powheg_hdampUP.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampUp_ttLF --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=4'
@@ -90,7 +90,7 @@ create-batch --jobName TTLJ_PowhegPythiaBkg_SYS_hdampUp --fileList $dataset_loc/
 create-batch --jobName TTLL_PowhegPythiaBkg_SYS_hdampUp --fileList $dataset_loc/dataset_TTTo2L2Nu_hdampUP.txt --cfg $cfg --transferDest $save_loc/TTLL_PowhegPythiaBkg_SYS_hdampUp --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=2 TTbarCatMC=0'
 create-batch --jobName TTJJ_PowhegPythiaBkg_SYS_hdampUp --fileList $dataset_loc/dataset_TTToHadronic_hdampUP.txt --cfg $cfg --transferDest $save_loc/TTJJ_PowhegPythiaBkg_SYS_hdampUp --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=2 TTbarCatMC=0'
 ### hdamp Down
-create-batch --jobName TTLJ_PowhegPythia_SYS_hdampDown_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_hdampDOWN.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythiai_SYS_hdampDown_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
+create-batch --jobName TTLJ_PowhegPythia_SYS_hdampDown_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_hdampDOWN.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampDown_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
 create-batch --jobName TTLJ_PowhegPythia_SYS_hdampDown_ttbj --fileList $dataset_loc/dataset_TTLJ_powheg_hdampDOWN.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampDown_ttbj --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=2'
 create-batch --jobName TTLJ_PowhegPythia_SYS_hdampDown_ttcc --fileList $dataset_loc/dataset_TTLJ_powheg_hdampDOWN.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampDown_ttcc --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=3'
 create-batch --jobName TTLJ_PowhegPythia_SYS_hdampDown_ttLF --fileList $dataset_loc/dataset_TTLJ_powheg_hdampDOWN.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_hdampDown_ttLF --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=4'
@@ -99,7 +99,7 @@ create-batch --jobName TTLJ_PowhegPythiaBkg_SYS_hdampDown --fileList $dataset_lo
 create-batch --jobName TTLL_PowhegPythiaBkg_SYS_hdampDown --fileList $dataset_loc/dataset_TTTo2L2Nu_hdampDOWN.txt --cfg $cfg --transferDest $save_loc/TTLL_PowhegPythiaBkg_SYS_hdampDown --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=2 TTbarCatMC=0'
 create-batch --jobName TTJJ_PowhegPythiaBkg_SYS_hdampDown --fileList $dataset_loc/dataset_TTToHadronic_hdampDOWN.txt --cfg $cfg --transferDest $save_loc/TTJJ_PowhegPythiaBkg_SYS_hdampDown --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=2 TTbarCatMC=0'
 ### TuneCP5 Up
-create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Up_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5up.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythiai_SYS_TuneCP5Up_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
+create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Up_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5up.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Up_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
 create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Up_ttbj --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5up.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Up_ttbj --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=2'
 create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Up_ttcc --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5up.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Up_ttcc --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=3'
 create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Up_ttLF --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5up.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Up_ttLF --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=4'
@@ -108,7 +108,7 @@ create-batch --jobName TTLJ_PowhegPythiaBkg_SYS_TuneCP5Up --fileList $dataset_lo
 create-batch --jobName TTLL_PowhegPythiaBkg_SYS_TuneCP5Up --fileList $dataset_loc/dataset_TTTo2L2Nu_TuneCP5up.txt --cfg $cfg --transferDest $save_loc/TTLL_PowhegPythiaBkg_SYS_TuneCP5Up --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=2 TTbarCatMC=0'
 create-batch --jobName TTJJ_PowhegPythiaBkg_SYS_TuneCP5Up --fileList $dataset_loc/dataset_TTToHadronic_TuneCP5up.txt --cfg $cfg --transferDest $save_loc/TTJJ_PowhegPythiaBkg_SYS_TuneCP5Up --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=2 TTbarCatMC=0'
 ### TuneCP5 Down
-create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Down_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5down.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythiai_SYS_TuneCP5Down_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
+create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Down_ttbb --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5down.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Down_ttbb --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=1'
 create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Down_ttbj --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5down.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Down_ttbj --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=2'
 create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Down_ttcc --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5down.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Down_ttcc --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=3'
 create-batch --jobName TTLJ_PowhegPythia_SYS_TuneCP5Down_ttLF --fileList $dataset_loc/dataset_TTLJ_powheg_TuneCP5down.txt --cfg $cfg --transferDest $save_loc/TTLJ_PowhegPythia_SYS_TuneCP5Down_ttLF --maxFiles 50 --args 'UserJSON=false runOnTTbarMC=1 TTbarCatMC=4'


### PR DESCRIPTION
1. Fill pdfweights in the same way in cat81x.
2. Remove muon isolation cut if doLooselepton is true.